### PR TITLE
Merge contribution automation

### DIFF
--- a/.github/workflows/add-openshift-version.yaml
+++ b/.github/workflows/add-openshift-version.yaml
@@ -1,0 +1,144 @@
+name: Add New OpenShift Version
+
+# Runs weekly and can be triggered manually.
+# Detects new OpenShift minor versions in community-operators-prod and opens
+# a PR to add them to this operator's FBC catalog_mapping in ci.yaml.
+on:
+  schedule:
+    # Run daily at 06:00 UTC
+    - cron: "0 6 * * *"
+  workflow_dispatch:
+
+env:
+  COMMUNITY_OPERATORS_PROD_REPO: redhat-openshift-ecosystem/community-operators-prod
+  OPERATOR_NAME: ecr-secret-operator
+  # The minimum OpenShift version this operator supports (must match minKubeVersion)
+  MIN_OCP_VERSION: "4.16"
+
+jobs:
+  detect-and-add-new-version:
+    name: Detect new OpenShift versions and open PR
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout community-operators-prod fork
+        uses: actions/checkout@v4
+        with:
+          repository: rh-mobb/community-operators-prod
+          token: ${{ secrets.OPERATORHUB_PR_TOKEN }}
+
+      - name: Sync fork with upstream
+        run: |
+          git remote add upstream \
+            https://github.com/${{ env.COMMUNITY_OPERATORS_PROD_REPO }}.git
+          git fetch upstream
+          git checkout main
+          git reset --hard upstream/main
+          git push origin main --force-with-lease
+
+      - name: Detect new OpenShift catalog versions
+        id: detect
+        run: |
+          # List all vX.Y catalog directories that exist in the upstream repo
+          AVAILABLE=$(ls catalogs/ | grep -E '^v[0-9]+\.[0-9]+$' | sort -V)
+          echo "Available catalogs: ${AVAILABLE}"
+
+          # Read versions already mapped in our operator's ci.yaml
+          MAPPED=$(python3 - <<'PYEOF'
+          import yaml
+
+          with open("operators/${{ env.OPERATOR_NAME }}/ci.yaml") as f:
+              config = yaml.safe_load(f)
+
+          versions = []
+          for mapping in config.get("fbc", {}).get("catalog_mapping", []):
+              versions.extend(mapping.get("catalog_names", []))
+
+          print("\n".join(versions))
+          PYEOF
+          )
+          echo "Already mapped: ${MAPPED}"
+
+          # Find versions that are available but not yet mapped,
+          # and are >= MIN_OCP_VERSION
+          NEW_VERSIONS=""
+          while IFS= read -r version; do
+            # Strip leading 'v' for numeric comparison
+            ver_num="${version#v}"
+            min_num="${{ env.MIN_OCP_VERSION }}"
+
+            # Compare using sort -V: if version sorts after min, include it
+            if [[ "$(printf '%s\n' "$min_num" "$ver_num" | sort -V | head -1)" == "$min_num" ]]; then
+              if ! echo "${MAPPED}" | grep -q "^${version}$"; then
+                NEW_VERSIONS="${NEW_VERSIONS} ${version}"
+              fi
+            fi
+          done <<< "${AVAILABLE}"
+
+          NEW_VERSIONS="${NEW_VERSIONS# }"  # trim leading space
+          echo "New versions to add: '${NEW_VERSIONS}'"
+          echo "new_versions=${NEW_VERSIONS}" >> "$GITHUB_OUTPUT"
+          echo "has_new=$([ -n "${NEW_VERSIONS}" ] && echo true || echo false)" >> "$GITHUB_OUTPUT"
+
+      - name: Add new versions to ci.yaml
+        if: steps.detect.outputs.has_new == 'true'
+        run: |
+          NEW_VERSIONS="${{ steps.detect.outputs.new_versions }}"
+
+          python3 - <<PYEOF
+          import yaml
+
+          ci_yaml_path = "operators/${{ env.OPERATOR_NAME }}/ci.yaml"
+
+          with open(ci_yaml_path) as f:
+              config = yaml.safe_load(f)
+
+          new_versions = "${NEW_VERSIONS}".split()
+
+          # Add each new version to the basic.yaml mapping (supported versions)
+          for mapping in config["fbc"]["catalog_mapping"]:
+              if mapping.get("template_name") == "basic.yaml":
+                  existing = mapping.get("catalog_names", [])
+                  for v in new_versions:
+                      if v not in existing:
+                          existing.append(v)
+                  # Sort versions so they appear in order
+                  mapping["catalog_names"] = sorted(
+                      existing,
+                      key=lambda x: [int(n) for n in x.lstrip("v").split(".")]
+                  )
+                  break
+
+          with open(ci_yaml_path, "w") as f:
+              yaml.dump(config, f, default_flow_style=False, sort_keys=False)
+
+          print(f"Added {new_versions} to {ci_yaml_path}")
+          PYEOF
+
+          echo "Updated ci.yaml:"
+          cat operators/${{ env.OPERATOR_NAME }}/ci.yaml
+
+      - name: Open PR with new version mapping
+        if: steps.detect.outputs.has_new == 'true'
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.OPERATORHUB_PR_TOKEN }}
+          branch: >-
+            operators/${{ env.OPERATOR_NAME }}/ocp-${{
+              steps.detect.outputs.new_versions }}
+          commit-message: |
+            operator ${{ env.OPERATOR_NAME }}: add OCP ${{ steps.detect.outputs.new_versions }} catalog mapping
+
+            Signed-off-by: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
+          title: >-
+            operator ${{ env.OPERATOR_NAME }}: add OCP
+            ${{ steps.detect.outputs.new_versions }} to catalog mapping
+          body: |
+            Adds OpenShift ${{ steps.detect.outputs.new_versions }} to the `basic.yaml` catalog mapping in `ci.yaml` for `${{ env.OPERATOR_NAME }}`.
+
+            This PR was opened automatically by the [add-openshift-version](https://github.com/rh-mobb/ecr-secret-operator/actions/workflows/add-openshift-version.yaml) workflow after detecting new OpenShift catalog directories in upstream `community-operators-prod`.
+
+            **Checklist before merging:**
+            - [ ] Confirm the operator has been tested on OpenShift ${{ steps.detect.outputs.new_versions }}
+            - [ ] Confirm no API deprecations affect this version
+          push-to-fork: rh-mobb/community-operators-prod

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version-file: go.mod
+          go-version: "1.23"
           cache: true
 
       - name: Install build tools
@@ -51,7 +51,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version-file: go.mod
+          go-version: "1.23"
           cache: true
 
       - name: Set up QEMU (for multi-arch builds)
@@ -59,8 +59,10 @@ jobs:
         with:
           platforms: linux/amd64,linux/arm64
 
-      - name: Set up Podman
-        uses: containers/podman-installer@v1
+      - name: Install Podman
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y podman
 
       - name: Log in to Quay.io
         # Only log in when we have registry credentials (not on forks)
@@ -102,7 +104,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version-file: go.mod
+          go-version: "1.23"
           cache: true
 
       - name: Install build tools
@@ -142,8 +144,10 @@ jobs:
           operator-sdk bundle validate ./bundle \
             --select-optional name=good-practices
 
-      - name: Set up Podman
-        uses: containers/podman-installer@v1
+      - name: Install Podman
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y podman
 
       - name: Log in to Quay.io
         if: ${{ env.HAS_QUAY_CREDENTIALS == 'true' }}
@@ -153,7 +157,7 @@ jobs:
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_PASSWORD }}
 
-      - name: Build bundle image (no push)
+      - name: Build bundle image
         run: |
           podman build \
             -f bundle.Dockerfile \

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,6 +41,8 @@ jobs:
     runs-on: ubuntu-latest
     # Image build is independent of tests — run both in parallel
     needs: []
+    env:
+      HAS_QUAY_CREDENTIALS: ${{ secrets.QUAY_USERNAME != '' && secrets.QUAY_PASSWORD != '' }}
 
     steps:
       - name: Checkout
@@ -62,7 +64,7 @@ jobs:
 
       - name: Log in to Quay.io
         # Only log in when we have registry credentials (not on forks)
-        if: ${{ secrets.QUAY_USERNAME != '' }}
+        if: ${{ env.HAS_QUAY_CREDENTIALS == 'true' }}
         uses: redhat-actions/podman-login@v1
         with:
           registry: quay.io
@@ -81,7 +83,7 @@ jobs:
       - name: Push PR operator image
         # Push a pr-<number> tag so it can be pulled for manual OLM testing.
         # Skipped on forks where QUAY_USERNAME is not available.
-        if: ${{ github.event_name == 'pull_request' && secrets.QUAY_USERNAME != '' }}
+        if: ${{ github.event_name == 'pull_request' && env.HAS_QUAY_CREDENTIALS == 'true' }}
         run: |
           podman manifest push \
             ${{ env.IMAGE_TAG_BASE }}:pr-${{ github.event.pull_request.number }}
@@ -90,6 +92,8 @@ jobs:
     name: Build and validate OLM bundle
     runs-on: ubuntu-latest
     needs: []
+    env:
+      HAS_QUAY_CREDENTIALS: ${{ secrets.QUAY_USERNAME != '' && secrets.QUAY_PASSWORD != '' }}
 
     steps:
       - name: Checkout
@@ -142,7 +146,7 @@ jobs:
         uses: containers/podman-installer@v1
 
       - name: Log in to Quay.io
-        if: ${{ secrets.QUAY_USERNAME != '' }}
+        if: ${{ env.HAS_QUAY_CREDENTIALS == 'true' }}
         uses: redhat-actions/podman-login@v1
         with:
           registry: quay.io
@@ -159,7 +163,7 @@ jobs:
       - name: Push PR bundle image
         # Push a pr-<number> tag so it can be pulled for manual OLM testing.
         # Skipped on forks where QUAY_USERNAME is not available.
-        if: ${{ github.event_name == 'pull_request' && secrets.QUAY_USERNAME != '' }}
+        if: ${{ github.event_name == 'pull_request' && env.HAS_QUAY_CREDENTIALS == 'true' }}
         run: |
           podman push \
             ${{ env.IMAGE_TAG_BASE }}-bundle:ci-${{ github.sha }} \

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+env:
+  IMAGE_TAG_BASE: quay.io/rh-mobb/ecr-secret-operator
+
 jobs:
   test:
     name: Test
@@ -32,3 +35,132 @@ jobs:
         with:
           name: coverage
           path: cover.out
+
+  build-image:
+    name: Build operator image
+    runs-on: ubuntu-latest
+    # Image build is independent of tests — run both in parallel
+    needs: []
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Set up QEMU (for multi-arch builds)
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: linux/amd64,linux/arm64
+
+      - name: Set up Podman
+        uses: containers/podman-installer@v1
+
+      - name: Log in to Quay.io
+        # Only log in when we have registry credentials (not on forks)
+        if: ${{ secrets.QUAY_USERNAME != '' }}
+        uses: redhat-actions/podman-login@v1
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_PASSWORD }}
+
+      - name: Build multi-arch operator image
+        # Build only — skip the test dependency inside podman-build by
+        # calling podman directly. Pushes are handled by publish-operatorhub.yaml.
+        run: |
+          podman build \
+            --platform linux/amd64,linux/arm64 \
+            --manifest ${{ env.IMAGE_TAG_BASE }}:pr-${{ github.event.pull_request.number || 'main' }} \
+            .
+
+      - name: Push PR operator image
+        # Push a pr-<number> tag so it can be pulled for manual OLM testing.
+        # Skipped on forks where QUAY_USERNAME is not available.
+        if: ${{ github.event_name == 'pull_request' && secrets.QUAY_USERNAME != '' }}
+        run: |
+          podman manifest push \
+            ${{ env.IMAGE_TAG_BASE }}:pr-${{ github.event.pull_request.number }}
+
+  build-bundle:
+    name: Build and validate OLM bundle
+    runs-on: ubuntu-latest
+    needs: []
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Install build tools
+        run: make controller-gen kustomize
+
+      - name: Install operator-sdk
+        run: |
+          OPERATOR_SDK_VERSION=v1.42.0
+          curl -sSLo /usr/local/bin/operator-sdk \
+            "https://github.com/operator-framework/operator-sdk/releases/download/${OPERATOR_SDK_VERSION}/operator-sdk_linux_amd64"
+          chmod +x /usr/local/bin/operator-sdk
+
+      - name: Generate OLM bundle
+        run: |
+          make bundle IMG=${{ env.IMAGE_TAG_BASE }}:ci-${{ github.sha }}
+
+      - name: Restore com.redhat.openshift.versions annotation
+        # make bundle regenerates annotations.yaml and drops custom annotations
+        run: |
+          if ! grep -q "com.redhat.openshift.versions" bundle/metadata/annotations.yaml; then
+            sed -i '/operators.operatorframework.io.metrics.project_layout/a\  com.redhat.openshift.versions: "v4.16"' \
+              bundle/metadata/annotations.yaml
+          fi
+
+      - name: Validate bundle — operatorframework suite
+        run: |
+          operator-sdk bundle validate ./bundle \
+            --select-optional suite=operatorframework
+
+      - name: Validate bundle — operatorhub
+        run: |
+          operator-sdk bundle validate ./bundle \
+            --select-optional name=operatorhub
+
+      - name: Validate bundle — good-practices
+        run: |
+          operator-sdk bundle validate ./bundle \
+            --select-optional name=good-practices
+
+      - name: Set up Podman
+        uses: containers/podman-installer@v1
+
+      - name: Log in to Quay.io
+        if: ${{ secrets.QUAY_USERNAME != '' }}
+        uses: redhat-actions/podman-login@v1
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_PASSWORD }}
+
+      - name: Build bundle image (no push)
+        run: |
+          podman build \
+            -f bundle.Dockerfile \
+            -t ${{ env.IMAGE_TAG_BASE }}-bundle:ci-${{ github.sha }} \
+            .
+
+      - name: Push PR bundle image
+        # Push a pr-<number> tag so it can be pulled for manual OLM testing.
+        # Skipped on forks where QUAY_USERNAME is not available.
+        if: ${{ github.event_name == 'pull_request' && secrets.QUAY_USERNAME != '' }}
+        run: |
+          podman push \
+            ${{ env.IMAGE_TAG_BASE }}-bundle:ci-${{ github.sha }} \
+            ${{ env.IMAGE_TAG_BASE }}-bundle:pr-${{ github.event.pull_request.number }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,34 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Install build tools
+        run: make controller-gen kustomize envtest
+
+      - name: Run tests
+        run: make test
+
+      - name: Upload coverage
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage
+          path: cover.out

--- a/.github/workflows/publish-operatorhub.yaml
+++ b/.github/workflows/publish-operatorhub.yaml
@@ -10,14 +10,34 @@ env:
   COMMUNITY_OPERATORS_REPO: k8s-operatorhub/community-operators
 
 jobs:
+  validate-secrets:
+    name: Validate required secrets are set
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check secrets
+        run: |
+          MISSING=""
+          [ -z "${{ secrets.QUAY_USERNAME }}"       ] && MISSING="${MISSING}\n  - QUAY_USERNAME"
+          [ -z "${{ secrets.QUAY_PASSWORD }}"       ] && MISSING="${MISSING}\n  - QUAY_PASSWORD"
+          [ -z "${{ secrets.OPERATORHUB_PR_TOKEN }}" ] && MISSING="${MISSING}\n  - OPERATORHUB_PR_TOKEN"
+          if [ -n "${MISSING}" ]; then
+            echo "❌ The following required secrets are not set:${MISSING}"
+            echo ""
+            echo "Configure them under Settings → Secrets and variables → Actions."
+            exit 1
+          fi
+          echo "✅ All required secrets are set"
+
   sync-forks:
     name: Sync community operator forks
+    needs: validate-secrets
     uses: ./.github/workflows/sync-forks.yaml
     secrets: inherit
 
   build-and-push:
     name: Build and push images
     runs-on: ubuntu-latest
+    needs: validate-secrets
     outputs:
       version: ${{ steps.version.outputs.VERSION }}
 

--- a/.github/workflows/publish-operatorhub.yaml
+++ b/.github/workflows/publish-operatorhub.yaml
@@ -10,6 +10,11 @@ env:
   COMMUNITY_OPERATORS_REPO: k8s-operatorhub/community-operators
 
 jobs:
+  sync-forks:
+    name: Sync community operator forks
+    uses: ./.github/workflows/sync-forks.yaml
+    secrets: inherit
+
   build-and-push:
     name: Build and push images
     runs-on: ubuntu-latest
@@ -109,7 +114,7 @@ jobs:
   publish-openshift-operatorhub:
     name: PR to community-operators-prod (FBC)
     runs-on: ubuntu-latest
-    needs: build-and-push
+    needs: [sync-forks, build-and-push]
 
     steps:
       - name: Download bundle artifact
@@ -121,7 +126,7 @@ jobs:
       - name: Checkout community-operators-prod fork
         uses: actions/checkout@v4
         with:
-          repository: ${{ env.COMMUNITY_OPERATORS_PROD_REPO }}
+          repository: rh-mobb/community-operators-prod
           path: community-operators-prod
           token: ${{ secrets.OPERATORHUB_PR_TOKEN }}
 
@@ -232,7 +237,7 @@ jobs:
   publish-public-operatorhub:
     name: PR to community-operators (semver)
     runs-on: ubuntu-latest
-    needs: build-and-push
+    needs: [sync-forks, build-and-push]
 
     steps:
       - name: Download bundle artifact
@@ -244,7 +249,7 @@ jobs:
       - name: Checkout community-operators fork
         uses: actions/checkout@v4
         with:
-          repository: ${{ env.COMMUNITY_OPERATORS_REPO }}
+          repository: rh-mobb/community-operators
           path: community-operators
           token: ${{ secrets.OPERATORHUB_PR_TOKEN }}
 

--- a/.github/workflows/publish-operatorhub.yaml
+++ b/.github/workflows/publish-operatorhub.yaml
@@ -1,0 +1,286 @@
+name: Publish to OperatorHub
+
+on:
+  release:
+    types: [published]
+
+env:
+  IMAGE_TAG_BASE: quay.io/rh-mobb/ecr-secret-operator
+  COMMUNITY_OPERATORS_PROD_REPO: redhat-openshift-ecosystem/community-operators-prod
+  COMMUNITY_OPERATORS_REPO: k8s-operatorhub/community-operators
+
+jobs:
+  build-and-push:
+    name: Build and push images
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.VERSION }}
+
+    steps:
+      - name: Checkout operator repo
+        uses: actions/checkout@v4
+
+      - name: Parse version from release tag
+        id: version
+        # Strip the leading 'v' from the tag (e.g. v0.6.0 → 0.6.0)
+        run: echo "VERSION=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Install operator-sdk
+        run: |
+          OPERATOR_SDK_VERSION=v1.42.0
+          curl -sSLo /usr/local/bin/operator-sdk \
+            "https://github.com/operator-framework/operator-sdk/releases/download/${OPERATOR_SDK_VERSION}/operator-sdk_linux_amd64"
+          chmod +x /usr/local/bin/operator-sdk
+
+      - name: Install kustomize and controller-gen
+        run: make kustomize controller-gen
+
+      - name: Set up Podman
+        uses: containers/podman-installer@v1
+
+      - name: Log in to Quay.io
+        uses: redhat-actions/podman-login@v1
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_PASSWORD }}
+
+      - name: Build and push multi-arch operator image
+        run: |
+          make podman-build podman-push \
+            IMG=${{ env.IMAGE_TAG_BASE }}:${{ github.ref_name }}
+
+      - name: Stamp VERSION, containerImage, and createdAt into sources
+        run: |
+          VERSION=${{ steps.version.outputs.VERSION }}
+          TAG=${{ github.ref_name }}
+          sed -i "s/^VERSION ?= .*/VERSION ?= ${VERSION}/" Makefile
+          sed -i "s|containerImage: .*|containerImage: ${{ env.IMAGE_TAG_BASE }}:${TAG}|" \
+            config/manifests/bases/ecr-secret-operator.clusterserviceversion.yaml
+          sed -i "s|createdAt: .*|createdAt: \"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"|" \
+            config/manifests/bases/ecr-secret-operator.clusterserviceversion.yaml
+
+      - name: Generate OLM bundle
+        run: make bundle IMG=${{ env.IMAGE_TAG_BASE }}:${{ github.ref_name }}
+
+      - name: Restore com.redhat.openshift.versions annotation
+        # make bundle regenerates annotations.yaml and drops custom annotations
+        run: |
+          if ! grep -q "com.redhat.openshift.versions" bundle/metadata/annotations.yaml; then
+            sed -i '/operators.operatorframework.io.metrics.project_layout/a\  com.redhat.openshift.versions: "v4.16"' \
+              bundle/metadata/annotations.yaml
+          fi
+
+      - name: Validate bundle
+        run: |
+          operator-sdk bundle validate ./bundle \
+            --select-optional suite=operatorframework
+          operator-sdk bundle validate ./bundle \
+            --select-optional name=operatorhub
+          operator-sdk bundle validate ./bundle \
+            --select-optional name=good-practices
+
+      - name: Build and push bundle image
+        run: |
+          make bundle-build bundle-push \
+            BUNDLE_IMG=${{ env.IMAGE_TAG_BASE }}-bundle:${{ github.ref_name }}
+
+      - name: Upload bundle as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: bundle
+          path: bundle/
+
+  # ------------------------------------------------------------------ #
+  # community-operators-prod  (OpenShift OperatorHub — uses FBC)
+  #
+  # FBC process:
+  #   1. Copy the bundle version directory (manifests + metadata)
+  #   2. Add the new version entry to catalog-templates/basic.yaml
+  #   3. Update release-config.yaml with the new replaces/skips graph
+  #   The pipeline renders the actual catalogs from these templates.
+  # ------------------------------------------------------------------ #
+  publish-openshift-operatorhub:
+    name: PR to community-operators-prod (FBC)
+    runs-on: ubuntu-latest
+    needs: build-and-push
+
+    steps:
+      - name: Download bundle artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: bundle
+          path: bundle/
+
+      - name: Checkout community-operators-prod fork
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ env.COMMUNITY_OPERATORS_PROD_REPO }}
+          path: community-operators-prod
+          token: ${{ secrets.OPERATORHUB_PR_TOKEN }}
+
+      - name: Copy bundle version directory
+        run: |
+          VERSION=${{ needs.build-and-push.outputs.version }}
+          DEST=community-operators-prod/operators/ecr-secret-operator/${VERSION}
+          mkdir -p "${DEST}"
+          cp -r bundle/manifests "${DEST}/"
+          cp -r bundle/metadata  "${DEST}/"
+
+      - name: Update catalog-templates/basic.yaml with new version
+        # Insert the new version entry at the top of the alpha channel entries list.
+        # The new entry replaces the previous latest version.
+        run: |
+          VERSION=${{ needs.build-and-push.outputs.version }}
+          PREV_VERSION=${{ github.ref_name }}   # full tag, used only for display
+          TEMPLATE=community-operators-prod/operators/ecr-secret-operator/catalog-templates/basic.yaml
+
+          # Find the current latest bundle entry name to use as 'replaces'
+          PREV_BUNDLE=$(grep "name: ecr-secret-operator.v" "${TEMPLATE}" | head -1 | awk '{print $2}')
+
+          # Insert the new channel entry before the first existing entry
+          python3 - <<PYEOF
+          import re, sys
+
+          with open("${TEMPLATE}") as f:
+              content = f.read()
+
+          new_entry = (
+              "  - name: ecr-secret-operator.v${VERSION}\n"
+              f"    replaces: {PREV_BUNDLE}\n"
+          )
+
+          # Insert after the 'entries:' line in the alpha channel block
+          content = content.replace(
+              "- entries:\n",
+              "- entries:\n" + new_entry,
+              1  # only the first occurrence (the alpha channel)
+          )
+
+          with open("${TEMPLATE}", "w") as f:
+              f.write(content)
+          PYEOF
+
+          echo "Updated ${TEMPLATE}:"
+          grep -A5 "- entries:" "${TEMPLATE}" | head -10
+
+      - name: Update release-config.yaml
+        run: |
+          VERSION=${{ needs.build-and-push.outputs.version }}
+          RELEASE_CONFIG=community-operators-prod/operators/ecr-secret-operator/release-config.yaml
+
+          # Find the current 'replaces' value to cascade it into 'skips'
+          CURRENT_REPLACES=$(grep "replaces:" "${RELEASE_CONFIG}" | awk '{print $2}')
+
+          python3 - <<PYEOF
+          import yaml, sys
+
+          with open("${RELEASE_CONFIG}") as f:
+              config = yaml.safe_load(f)
+
+          template = config["catalog_templates"][0]
+          current_replaces = template.get("replaces", "")
+          current_skips = template.get("skips", [])
+
+          # The old 'replaces' target becomes a skip entry in the new version
+          if current_replaces and current_replaces not in current_skips:
+              current_skips.insert(0, current_replaces)
+
+          template["replaces"] = "ecr-secret-operator.v${VERSION}"
+          # Remove the new version itself from skips if accidentally present
+          template["skips"] = [s for s in current_skips if s != "ecr-secret-operator.v${VERSION}"]
+
+          with open("${RELEASE_CONFIG}", "w") as f:
+              yaml.dump(config, f, default_flow_style=False, sort_keys=False)
+          PYEOF
+
+          echo "Updated ${RELEASE_CONFIG}:"
+          cat "${RELEASE_CONFIG}"
+
+      - name: Open PR to community-operators-prod
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.OPERATORHUB_PR_TOKEN }}
+          path: community-operators-prod
+          branch: operators/ecr-secret-operator/${{ needs.build-and-push.outputs.version }}
+          commit-message: |
+            operator ecr-secret-operator (${{ needs.build-and-push.outputs.version }})
+
+            Signed-off-by: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
+          title: "operator ecr-secret-operator (${{ needs.build-and-push.outputs.version }})"
+          body: |
+            Release `${{ github.ref_name }}` of [ecr-secret-operator](https://github.com/rh-mobb/ecr-secret-operator).
+
+            See the [CHANGELOG](https://github.com/rh-mobb/ecr-secret-operator/blob/main/CHANGELOG.md) for details.
+
+            ---
+            *This PR was opened automatically by the [publish-operatorhub](https://github.com/rh-mobb/ecr-secret-operator/actions/workflows/publish-operatorhub.yaml) workflow.*
+          push-to-fork: rh-mobb/community-operators-prod
+
+  # ------------------------------------------------------------------ #
+  # community-operators  (Public OperatorHub — uses semver bundle copy)
+  #
+  # Semver process: copy the bundle version directory, the pipeline
+  # derives the upgrade graph automatically from version numbers.
+  # ------------------------------------------------------------------ #
+  publish-public-operatorhub:
+    name: PR to community-operators (semver)
+    runs-on: ubuntu-latest
+    needs: build-and-push
+
+    steps:
+      - name: Download bundle artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: bundle
+          path: bundle/
+
+      - name: Checkout community-operators fork
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ env.COMMUNITY_OPERATORS_REPO }}
+          path: community-operators
+          token: ${{ secrets.OPERATORHUB_PR_TOKEN }}
+
+      - name: Copy bundle version directory
+        run: |
+          VERSION=${{ needs.build-and-push.outputs.version }}
+          DEST=community-operators/operators/ecr-secret-operator/${VERSION}
+          mkdir -p "${DEST}"
+          cp -r bundle/manifests "${DEST}/"
+          cp -r bundle/metadata  "${DEST}/"
+
+          CI_YAML=community-operators/operators/ecr-secret-operator/ci.yaml
+          if [ ! -f "${CI_YAML}" ]; then
+            cat > "${CI_YAML}" <<'EOF'
+          addReviewersToPR:
+            enabled: false
+          reviewers: []
+          EOF
+          fi
+
+      - name: Open PR to community-operators
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.OPERATORHUB_PR_TOKEN }}
+          path: community-operators
+          branch: operators/ecr-secret-operator/${{ needs.build-and-push.outputs.version }}
+          commit-message: |
+            operator ecr-secret-operator (${{ needs.build-and-push.outputs.version }})
+
+            Signed-off-by: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
+          title: "operator ecr-secret-operator (${{ needs.build-and-push.outputs.version }})"
+          body: |
+            Release `${{ github.ref_name }}` of [ecr-secret-operator](https://github.com/rh-mobb/ecr-secret-operator).
+
+            See the [CHANGELOG](https://github.com/rh-mobb/ecr-secret-operator/blob/main/CHANGELOG.md) for details.
+
+            ---
+            *This PR was opened automatically by the [publish-operatorhub](https://github.com/rh-mobb/ecr-secret-operator/actions/workflows/publish-operatorhub.yaml) workflow.*
+          push-to-fork: rh-mobb/community-operators

--- a/.github/workflows/publish-operatorhub.yaml
+++ b/.github/workflows/publish-operatorhub.yaml
@@ -53,7 +53,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version-file: go.mod
+          go-version: "1.23"
           cache: true
 
       - name: Install operator-sdk
@@ -66,8 +66,10 @@ jobs:
       - name: Install kustomize and controller-gen
         run: make kustomize controller-gen
 
-      - name: Set up Podman
-        uses: containers/podman-installer@v1
+      - name: Install Podman
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y podman
 
       - name: Log in to Quay.io
         uses: redhat-actions/podman-login@v1

--- a/.github/workflows/sync-forks.yaml
+++ b/.github/workflows/sync-forks.yaml
@@ -1,0 +1,52 @@
+name: Sync Forks
+
+on:
+  workflow_call:
+  workflow_dispatch:
+
+env:
+  COMMUNITY_OPERATORS_PROD_REPO: redhat-openshift-ecosystem/community-operators-prod
+  COMMUNITY_OPERATORS_REPO: k8s-operatorhub/community-operators
+
+jobs:
+  sync-community-operators-prod:
+    name: Sync rh-mobb/community-operators-prod
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout fork
+        uses: actions/checkout@v4
+        with:
+          repository: rh-mobb/community-operators-prod
+          token: ${{ secrets.OPERATORHUB_PR_TOKEN }}
+
+      - name: Sync main with upstream
+        run: |
+          git remote add upstream \
+            https://github.com/${{ env.COMMUNITY_OPERATORS_PROD_REPO }}.git
+          git fetch upstream
+          git checkout main
+          git reset --hard upstream/main
+          git push origin main --force-with-lease
+          echo "✅ rh-mobb/community-operators-prod synced with upstream"
+
+  sync-community-operators:
+    name: Sync rh-mobb/community-operators
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout fork
+        uses: actions/checkout@v4
+        with:
+          repository: rh-mobb/community-operators
+          token: ${{ secrets.OPERATORHUB_PR_TOKEN }}
+
+      - name: Sync main with upstream
+        run: |
+          git remote add upstream \
+            https://github.com/${{ env.COMMUNITY_OPERATORS_REPO }}.git
+          git fetch upstream
+          git checkout main
+          git reset --hard upstream/main
+          git push origin main --force-with-lease
+          echo "✅ rh-mobb/community-operators synced with upstream"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,113 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.5.0] — 2026-03-05
+
+### Bug Fixes
+
+- **Fixed non-stop reconciliation loop.** The controller was unconditionally calling `client.Update` on every reconcile cycle, even immediately after creating a new secret. The update logic is now only executed when the secret already exists. ([#25](https://github.com/rh-mobb/ecr-secret-operator/pull/25))
+- **Fixed CR status never reaching `Updated` on first reconcile.** `Status.Phase` was only being set inside the update code path, so a freshly created secret would never have its status reflect success. The status is now set correctly after both create and update operations. ([#25](https://github.com/rh-mobb/ecr-secret-operator/pull/25))
+
+### Changes
+
+- **Replaced deprecated `gcr.io/kubebuilder/kube-rbac-proxy` image.** The `kube-rbac-proxy` sidecar image has been migrated from the deprecated Google Container Registry (`gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0`) to the canonical upstream image on Quay.io, pinned by digest for supply-chain security: `quay.io/brancz/kube-rbac-proxy:v0.21.0@sha256:059a43ab03f230eedb7dde2eb0d910a41e9d7ee04efff0f5cdc7ee614111397a`. ([#23](https://github.com/rh-mobb/ecr-secret-operator/pull/23))
+- **Renamed default generated secret from `ecr-docker-secret` to `ecr-credentials`.** All sample manifests, documentation, and the OLM CSV have been updated to use `ecr-credentials` as the example `generated_secret_name`. **This is not a breaking change** — the field is user-configured in the CR spec and existing deployments are unaffected. ([#24](https://github.com/rh-mobb/ecr-secret-operator/pull/24))
+- **Added `GenerationChangedPredicate` event filter.** Both controllers now ignore status-only updates, preventing spurious reconcile triggers from status writes back to the API server. ([#25](https://github.com/rh-mobb/ecr-secret-operator/pull/25))
+- **Build system migrated from Docker to Podman with multi-architecture support.** The Makefile now uses Podman and builds manifest lists targeting both `linux/amd64` and `linux/arm64`. The operator image base is now `quay.io/rh-mobb/ecr-secret-operator`.
+- **Added Apache 2.0 license.** ([#21](https://github.com/rh-mobb/ecr-secret-operator/pull/21))
+
+### OLM / OperatorHub
+
+- Minimum Kubernetes version set to `1.29.0` (OpenShift 4.16+).
+- Upgrade graph covers all previously published versions (`v0.1.1` through `v0.4.1`) via `replaces` and `skips` fields.
+- Default channel set to `alpha`.
+
+### Upgrade Notes
+
+Users upgrading from any prior version (`v0.1.1` – `v0.4.1`) can upgrade directly to `v0.5.0` — no intermediate upgrades are required. Existing CRs and their `generated_secret_name` values are fully preserved.
+
+---
+
+## [0.4.1] — 2023-04-14
+
+### Changes
+
+- Added `--enable-oci` flag when creating ArgoCD Helm repo secrets to support OCI-based Helm registries.
+- Documentation updates to README.
+
+---
+
+## [0.4.0] — 2023-04-03
+
+### Features
+
+- **Added `ArgoHelmRepoSecret` CRD.** New custom resource to automatically manage ArgoCD Helm repository credentials backed by ECR tokens.
+- Upgraded Go module and Go version dependencies. ([#12](https://github.com/rh-mobb/ecr-secret-operator/pull/12))
+
+### Changes
+
+- Documentation updates for README and IAM setup guides. ([#11](https://github.com/rh-mobb/ecr-secret-operator/pull/11))
+
+---
+
+## [0.3.2] — 2022-08-15
+
+### Bug Fixes
+
+- **Fixed hardcoded AWS region.** The region is now read from the CR spec rather than being hardcoded in the controller. ([#10](https://github.com/rh-mobb/ecr-secret-operator/pull/10))
+
+### Changes
+
+- Updated OLM bundle manifests.
+- Added controller test coverage for region handling.
+
+---
+
+## [0.3.1] — 2022-05-09
+
+### Changes
+
+- Made the AWS credentials secret optional to support workload identity / IRSA configurations.
+- Fixed errors related to `ClusterVersion` resource access.
+- Updated OLM bundle manifests to v0.3.1.
+
+---
+
+## [0.3.0] — 2022-05-08
+
+### Features
+
+- **Added STS / Assume Role support.** AWS authentication logic has been moved out of the operator binary and into a mounted credentials file, enabling STS `AssumeRoleWithWebIdentity` (IRSA) configurations. ([#5](https://github.com/rh-mobb/ecr-secret-operator/pull/5))
+- Updated OLM bundle manifests to v0.3.0.
+
+---
+
+## [0.2.1] — 2022-05-03
+
+### Changes
+
+- Added operator description metadata.
+
+---
+
+## [0.2.0] — 2022-05-03
+
+### Features
+
+- **Added multi-namespace support.** The operator can now be configured to run in `OwnNamespace`, `SingleNamespace`, `MultiNamespace`, or `AllNamespaces` install modes. ([#4](https://github.com/rh-mobb/ecr-secret-operator/pull/4))
+- Updated OLM bundle to v2.0 media type.
+
+---
+
+## [0.1.1] — 2022-04-28
+
+### Features
+
+- Initial public release of the ECR Secret Operator.
+- Automatically refreshes AWS ECR authentication tokens as Kubernetes `kubernetes.io/dockerconfigjson` secrets.
+- Configurable refresh frequency via the `Secret` CRD `spec.frequency` field.
+- OLM bundle and OperatorHub metadata included.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,7 +54,11 @@ You also need:
 ├── docs/                  # IAM setup guides
 ├── ecr/                   # AWS ECR token generation
 ├── samples/               # End-user sample CRs
-├── .github/workflows/     # GitHub Actions CI and release workflows
+├── .github/workflows/
+│   ├── ci.yaml                    # PR and push: test, build image, build+validate bundle
+│   ├── publish-operatorhub.yaml   # Release: build, push, open OperatorHub PRs
+│   ├── sync-forks.yaml            # Reusable: sync community-operators forks with upstream
+│   └── add-openshift-version.yaml # Daily: detect new OCP versions, open catalog PR
 ├── Dockerfile             # Multi-arch operator image build
 ├── Makefile               # All build, test, and release targets
 └── PROJECT                # Operator-SDK / Kubebuilder project metadata
@@ -219,9 +223,104 @@ oc delete project test-ecr-secret-operator ecr-secret-operator
 
 ## Testing via OLM
 
-This validates the operator exactly as OperatorHub would install it.
+OLM testing can be done against either a **PR build** (before merging) or a **release build** (pre-release smoke test). Both approaches use `operator-sdk run bundle` to install the operator exactly as OperatorHub would.
 
-### 1. Generate and push the bundle image
+### Testing a PR build
+
+Every pull request automatically builds and pushes tagged images to quay.io via the CI workflow:
+
+| Image | Tag format | Example |
+|---|---|---|
+| Operator image | `pr-<number>` | `quay.io/rh-mobb/ecr-secret-operator:pr-42` |
+| Bundle image | `pr-<number>` | `quay.io/rh-mobb/ecr-secret-operator-bundle:pr-42` |
+
+To find the PR number, check the pull request URL or run:
+
+```bash
+gh pr list
+```
+
+Ensure the CI workflow has completed and both images are publicly readable on quay.io before proceeding.
+
+#### 1. Create the namespace and AWS credentials secret
+
+```bash
+oc new-project ecr-secret-operator
+
+# Replace with your IAM role ARN
+cat <<EOF > /tmp/credentials
+[default]
+role_arn = arn:aws:iam::<ACCOUNT_ID>:role/<ROLE_NAME>
+web_identity_token_file = /var/run/secrets/openshift/serviceaccount/token
+EOF
+
+oc create secret generic aws-ecr-cloud-credentials \
+  --from-file=credentials=/tmp/credentials \
+  -n ecr-secret-operator
+```
+
+#### 2. Install the PR build via OLM
+
+```bash
+PR=<PR_NUMBER>
+
+operator-sdk run bundle \
+  quay.io/rh-mobb/ecr-secret-operator-bundle:pr-${PR} \
+  --namespace ecr-secret-operator
+```
+
+#### 3. Verify the CSV reached Succeeded
+
+```bash
+oc get csv -n ecr-secret-operator -w
+```
+
+#### 4. Create a test CR and confirm reconciliation
+
+```bash
+oc new-project test-ecr-secret-operator
+```
+
+```yaml
+apiVersion: ecr.mobb.redhat.com/v1alpha1
+kind: Secret
+metadata:
+  name: ecr-secret
+  namespace: test-ecr-secret-operator
+spec:
+  generated_secret_name: ecr-credentials
+  ecr_registry: <ACCOUNT_ID>.dkr.ecr.<REGION>.amazonaws.com
+  frequency: 10h
+  region: <REGION>
+```
+
+```bash
+oc apply -f test-cr.yaml
+
+# CR status should show Phase: Updated
+oc get secret.ecr.mobb.redhat.com ecr-secret \
+  -n test-ecr-secret-operator \
+  -o jsonpath='{.status}' | jq
+
+# The generated secret should contain a valid ECR token
+oc get secret ecr-credentials -n test-ecr-secret-operator \
+  -o jsonpath='{.data.\.dockerconfigjson}' | base64 -d | jq
+```
+
+#### 5. Tear down
+
+```bash
+operator-sdk cleanup ecr-secret-operator --namespace ecr-secret-operator
+oc delete project test-ecr-secret-operator ecr-secret-operator
+```
+
+---
+
+### Testing a release build
+
+Use this flow as the final pre-release smoke test before creating the GitHub Release.
+
+#### 1. Generate and push the bundle image
 
 ```bash
 make bundle IMG=quay.io/rh-mobb/ecr-secret-operator:v<VERSION>
@@ -232,7 +331,7 @@ make bundle-build bundle-push \
 
 Ensure the bundle image is publicly readable on quay.io before proceeding.
 
-### 2. Install via OLM
+#### 2. Install via OLM
 
 ```bash
 oc new-project ecr-secret-operator
@@ -252,15 +351,15 @@ operator-sdk run bundle quay.io/rh-mobb/ecr-secret-operator-bundle:v<VERSION> \
   --namespace ecr-secret-operator
 ```
 
-### 3. Verify the CSV reached Succeeded
+#### 3. Verify the CSV reached Succeeded
 
 ```bash
 oc get csv -n ecr-secret-operator -w
 ```
 
-### 4. Run through the manual test steps above (Create a test CR onwards)
+#### 4. Run through the Create a test CR and confirm reconciliation steps above
 
-### 5. Tear down
+#### 5. Tear down
 
 ```bash
 operator-sdk cleanup ecr-secret-operator --namespace ecr-secret-operator
@@ -372,29 +471,76 @@ Once both PRs are merged, the new version will appear in OperatorHub within a fe
 
 ## GitHub Actions Workflows
 
-Two workflows live in `.github/workflows/`:
+Four workflows live in `.github/workflows/`:
 
 ### `ci.yaml` — Continuous Integration
 
-Triggers on every push to `main` and every pull request targeting `main`.
+Triggers on every push to `main` and every pull request targeting `main`. All three jobs run in parallel.
 
-| Step | What it does |
+| Job | What it does |
 |---|---|
-| Checkout | Checks out the repository |
-| Set up Go | Installs Go using the version in `go.mod` |
-| Install build tools | Runs `make controller-gen kustomize envtest` |
-| Run tests | Runs `make test` (includes `manifests`, `generate`, `fmt`, `vet`) |
-| Upload coverage | Saves `cover.out` as a workflow artifact |
+| `test` | Installs build tools, runs `make test` (includes `manifests`, `generate`, `fmt`, `vet`, and the full Ginkgo/envtest suite), uploads `cover.out` as an artifact |
+| `build-image` | Builds the multi-arch (`linux/amd64` + `linux/arm64`) operator image using Podman. On PRs, pushes the image to `quay.io/rh-mobb/ecr-secret-operator:pr-<number>` so it can be pulled for manual OLM testing |
+| `build-bundle` | Installs `operator-sdk`, runs `make bundle`, restores the `com.redhat.openshift.versions` annotation, validates the bundle against the `operatorframework`, `operatorhub`, and `good-practices` validator suites, then builds the bundle image. On PRs, pushes it to `quay.io/rh-mobb/ecr-secret-operator-bundle:pr-<number>` |
+
+All three jobs must pass before a PR can be merged.
+
+PR image tags are ephemeral — they are intended for manual testing only and will be overwritten by subsequent PRs with the same number. Production images are only published by the `publish-operatorhub.yaml` workflow on release.
+
+### `sync-forks.yaml` — Fork Sync
+
+A reusable workflow (`workflow_call`) invoked automatically by `publish-operatorhub.yaml` before any PR is opened. Can also be triggered manually via `workflow_dispatch` if needed.
+
+```bash
+# Trigger manually if needed before a release
+gh workflow run sync-forks.yaml
+```
+
+Keeps both forks' `main` branches as exact mirrors of upstream so that release PRs only contain operator-specific changes.
 
 ### `publish-operatorhub.yaml` — Release and Publish
 
-Triggers when a GitHub Release is published.
+Triggers when a GitHub Release is published. Job execution order:
 
-| Job | Runs on | What it does |
-|---|---|---|
-| `build-and-push` | `ubuntu-latest` | Builds multi-arch operator image, generates and validates OLM bundle, builds and pushes bundle image, uploads bundle as artifact |
-| `publish-openshift-operatorhub` | `ubuntu-latest` | Copies bundle into the FBC-based `community-operators-prod` fork, updates `catalog-templates/basic.yaml` and `release-config.yaml` with the new version's upgrade graph, opens PR |
-| `publish-public-operatorhub` | `ubuntu-latest` | Copies bundle into the semver-based `community-operators` fork, opens PR |
+```
+release published
+      │
+      ├── sync-forks (reusable)     ← syncs both forks in parallel
+      │       ├── sync community-operators-prod
+      │       └── sync community-operators
+      │
+      ├── build-and-push            ← builds images, generates bundle
+      │
+      └── (both of the above complete)
+              │
+              ├── publish-openshift-operatorhub  ← FBC PR to community-operators-prod
+              └── publish-public-operatorhub     ← semver PR to community-operators
+```
+
+| Job | What it does |
+|---|---|
+| `sync-forks` | Calls `sync-forks.yaml` to reset both fork `main` branches to upstream before any changes are made |
+| `build-and-push` | Builds multi-arch operator image, generates and validates OLM bundle, builds and pushes bundle image, uploads bundle as artifact |
+| `publish-openshift-operatorhub` | Copies bundle into the FBC-based `community-operators-prod` fork, updates `catalog-templates/basic.yaml` and `release-config.yaml`, opens PR |
+| `publish-public-operatorhub` | Copies bundle into the semver-based `community-operators` fork, opens PR |
+
+### `add-openshift-version.yaml` — New OpenShift Version Detection
+
+Runs daily at 06:00 UTC and can also be triggered manually. Detects when Red Hat adds a new OpenShift minor version catalog directory (e.g. `v4.22`) to `community-operators-prod` that isn't yet listed in this operator's `ci.yaml` `catalog_mapping`, and automatically opens a PR to add it.
+
+The workflow:
+1. Syncs the `rh-mobb/community-operators-prod` fork with upstream
+2. Lists all `vX.Y` catalog directories present in the upstream `catalogs/` directory
+3. Compares them against the versions already in `operators/ecr-secret-operator/ci.yaml`
+4. For any new version at or above `v4.16` (the operator's `minKubeVersion`), adds it to the `basic.yaml` catalog mapping
+5. Opens a PR to `community-operators-prod` with a checklist reminding the reviewer to confirm the operator has been tested on the new version
+
+```bash
+# Trigger manually if you want to check for new versions immediately
+gh workflow run add-openshift-version.yaml
+```
+
+> **Note:** The PR opened by this workflow adds the new version to the FBC catalog mapping only. It does **not** create a new operator release — the existing latest bundle will be made available on the new OpenShift version. If the new OpenShift version requires code changes (e.g. due to API deprecations), create a full release instead.
 
 ### Required repository secrets
 
@@ -404,19 +550,14 @@ Configure these under **Settings → Secrets and variables → Actions**:
 |---|---|
 | `QUAY_USERNAME` | Quay.io robot account username (e.g. `rh-mobb+robot`) |
 | `QUAY_PASSWORD` | Quay.io robot account token |
-| `OPERATORHUB_PR_TOKEN` | GitHub Personal Access Token (classic) with `public_repo` scope, belonging to an account that has forked both community repos under the `rh-mobb` org |
+| `OPERATORHUB_PR_TOKEN` | Fine-grained Personal Access Token belonging to `rh-mobb-bot` with **Contents: read/write**, **Pull requests: read/write**, and **Workflows: read/write** on `rh-mobb/ecr-secret-operator`, `rh-mobb-bot/community-operators-prod`, and `rh-mobb-bot/community-operators` |
 
-### Required forks
+### Required bot account and forks
 
-The `publish-operatorhub` workflow pushes to forks before opening upstream PRs. Ensure these forks exist under the `rh-mobb` org:
+The workflows use a dedicated bot account (`rh-mobb-bot`) rather than a personal account so that automation is not tied to any individual's credentials. The token must cover three repositories with the following permissions:
 
-```bash
-gh repo fork redhat-openshift-ecosystem/community-operators-prod \
-  --org rh-mobb --clone=false
-
-gh repo fork k8s-operatorhub/community-operators \
-  --org rh-mobb --clone=false
-```
+- `rh-mobb-bot/community-operators-prod` and `rh-mobb-bot/community-operators`: **Contents** read/write, **Pull requests** read/write
+- `rh-mobb/ecr-secret-operator`: **Contents** read/write, **Pull requests** read/write, **Workflows** read/write
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,428 @@
+# Contributing to ECR Secret Operator
+
+Thank you for your interest in contributing. This guide covers everything you need to build, test, and release the operator.
+
+## Table of Contents
+
+- [Prerequisites](#prerequisites)
+- [Repository Layout](#repository-layout)
+- [Development Setup](#development-setup)
+- [Making Changes](#making-changes)
+- [Running Tests](#running-tests)
+- [Building the Operator Image](#building-the-operator-image)
+- [Deploying to OpenShift for Manual Testing](#deploying-to-openshift-for-manual-testing)
+- [Testing via OLM](#testing-via-olm)
+- [Releasing to OperatorHub](#releasing-to-operatorhub)
+- [GitHub Actions Workflows](#github-actions-workflows)
+- [Commit and PR Guidelines](#commit-and-pr-guidelines)
+
+---
+
+## Prerequisites
+
+| Tool | Minimum Version | Install |
+|---|---|---|
+| Go | 1.19 | https://go.dev/dl |
+| Podman | 4.x | https://podman.io/docs/installation |
+| kubectl / oc | any | https://docs.openshift.com/container-platform/latest/cli_reference/openshift_cli/getting-started-cli.html |
+| operator-sdk | v1.28+ | https://sdk.operatorframework.io/docs/installation |
+| GNU Make | any |  |
+
+You also need:
+
+- An OpenShift cluster configured with [STS/OIDC](https://docs.openshift.com/container-platform/4.16/authentication/managing_cloud_provider_credentials/cco-mode-sts.html) for manual and OLM testing. It is recommended to test this on a ROSA with HCP cluster.
+- An AWS IAM role with `ecr:GetAuthorizationToken` permission, configured to trust the cluster's OIDC provider. See [docs/iam_assume_role.md](docs/iam_assume_role.md) for setup instructions.
+
+---
+
+## Repository Layout
+
+```
+.
+├── api/v1alpha1/          # CRD type definitions (Secret, ArgoHelmRepoSecret)
+├── bundle/                # Generated OLM bundle (do not edit manually)
+│   ├── manifests/         # CSV, CRDs, RBAC manifests
+│   └── metadata/          # OLM channel and version annotations
+├── bundle.Dockerfile      # Dockerfile used to build the bundle image
+├── config/                # Kustomize bases and overlays
+│   ├── default/           # Default deployment overlay (includes kube-rbac-proxy)
+│   ├── manager/           # Operator Deployment definition
+│   ├── manifests/bases/   # Base CSV template (source of truth for make bundle)
+│   ├── rbac/              # RBAC roles and bindings
+│   └── samples/           # Sample CR manifests
+├── controllers/           # Reconciliation logic
+├── docs/                  # IAM setup guides
+├── ecr/                   # AWS ECR token generation
+├── samples/               # End-user sample CRs
+├── .github/workflows/     # GitHub Actions CI and release workflows
+├── Dockerfile             # Multi-arch operator image build
+├── Makefile               # All build, test, and release targets
+└── PROJECT                # Operator-SDK / Kubebuilder project metadata
+```
+
+---
+
+## Development Setup
+
+```bash
+git clone git@github.com:rh-mobb/ecr-secret-operator.git
+cd ecr-secret-operator
+
+# Download all Go dependencies
+go mod download
+
+# Install local build tools (controller-gen, kustomize, setup-envtest)
+make controller-gen kustomize envtest
+```
+
+---
+
+## Making Changes
+
+### CRD API types
+
+Type definitions live in `api/v1alpha1/`. After editing them, regenerate CRD manifests and DeepCopy methods:
+
+```bash
+make manifests generate
+```
+
+### Controller logic
+
+Controllers live in `controllers/`. No code generation is required after editing them — just run the tests.
+
+### RBAC
+
+RBAC rules are derived from `// +kubebuilder:rbac` markers in the controller source files. After changing markers, regenerate:
+
+```bash
+make manifests
+```
+
+---
+
+## Running Tests
+
+The test suite uses [Ginkgo](https://onsi.github.io/ginkgo/) with [envtest](https://book.kubebuilder.io/reference/envtest.html), which runs a real `kube-apiserver` locally — no cluster required.
+
+```bash
+make test
+```
+
+This runs `manifests`, `generate`, `fmt`, `vet`, and then the full test suite. Coverage output is written to `cover.out`.
+
+To view coverage in a browser:
+
+```bash
+go tool cover -html=cover.out
+```
+
+---
+
+## Building the Operator Image
+
+The operator image is built as a multi-architecture manifest list (`linux/amd64` and `linux/arm64`) using Podman.
+
+```bash
+# Log in to the registry first
+podman login quay.io
+
+# Build and push (runs make test first)
+make podman-build podman-push IMG=quay.io/rh-mobb/ecr-secret-operator:v<VERSION>
+```
+
+To build without pushing (useful for local inspection):
+
+```bash
+podman build --platform linux/amd64,linux/arm64 --manifest ecr-secret-operator:dev .
+```
+
+---
+
+## Deploying to OpenShift for Manual Testing
+
+### 1. Create the namespace and AWS credentials secret
+
+The operator authenticates to AWS using STS/IRSA (IAM Roles for Service Accounts). The credentials secret must use the `credentials` file format expected by the AWS SDK — not static access keys.
+
+First, follow [docs/iam_assume_role.md](docs/iam_assume_role.md) to create an IAM role that trusts your cluster's OIDC provider. Then:
+
+```bash
+oc new-project ecr-secret-operator
+
+# Replace with your IAM role ARN
+cat <<EOF > /tmp/credentials
+[default]
+role_arn = arn:aws:iam::<ACCOUNT_ID>:role/<ROLE_NAME>
+web_identity_token_file = /var/run/secrets/openshift/serviceaccount/token
+EOF
+
+oc create secret generic aws-ecr-cloud-credentials \
+  --from-file=credentials=/tmp/credentials \
+  -n ecr-secret-operator
+```
+
+### 2. Deploy
+
+```bash
+make deploy IMG=quay.io/rh-mobb/ecr-secret-operator:v<VERSION>
+```
+
+### 3. Verify
+
+```bash
+oc get pods -n ecr-secret-operator
+oc logs -n ecr-secret-operator -l control-plane=controller-manager -c manager -f
+```
+
+### 4. Create a test CR
+
+```yaml
+apiVersion: ecr.mobb.redhat.com/v1alpha1
+kind: Secret
+metadata:
+  name: ecr-secret
+  namespace: test-ecr-secret-operator
+spec:
+  generated_secret_name: ecr-credentials
+  ecr_registry: <ACCOUNT_ID>.dkr.ecr.<REGION>.amazonaws.com
+  frequency: 10h
+  region: <REGION>
+```
+
+```bash
+oc new-project test-ecr-secret-operator
+oc apply -f test-cr.yaml
+```
+
+### 5. Confirm reconciliation
+
+```bash
+# CR status should show Phase: Updated
+oc get secret.ecr.mobb.redhat.com ecr-secret \
+  -n test-ecr-secret-operator \
+  -o jsonpath='{.status}' | jq
+
+# The generated secret should contain a valid ECR token
+oc get secret ecr-credentials -n test-ecr-secret-operator \
+  -o jsonpath='{.data.\.dockerconfigjson}' | base64 -d | jq
+```
+
+### 6. Tear down
+
+```bash
+make undeploy
+oc delete project test-ecr-secret-operator ecr-secret-operator
+```
+
+---
+
+## Testing via OLM
+
+This validates the operator exactly as OperatorHub would install it.
+
+### 1. Generate and push the bundle image
+
+```bash
+make bundle IMG=quay.io/rh-mobb/ecr-secret-operator:v<VERSION>
+
+make bundle-build bundle-push \
+  BUNDLE_IMG=quay.io/rh-mobb/ecr-secret-operator-bundle:v<VERSION>
+```
+
+Ensure the bundle image is publicly readable on quay.io before proceeding.
+
+### 2. Install via OLM
+
+```bash
+oc new-project ecr-secret-operator
+
+# Replace with your IAM role ARN
+cat <<EOF > /tmp/credentials
+[default]
+role_arn = arn:aws:iam::<ACCOUNT_ID>:role/<ROLE_NAME>
+web_identity_token_file = /var/run/secrets/openshift/serviceaccount/token
+EOF
+
+oc create secret generic aws-ecr-cloud-credentials \
+  --from-file=credentials=/tmp/credentials \
+  -n ecr-secret-operator
+
+operator-sdk run bundle quay.io/rh-mobb/ecr-secret-operator-bundle:v<VERSION> \
+  --namespace ecr-secret-operator
+```
+
+### 3. Verify the CSV reached Succeeded
+
+```bash
+oc get csv -n ecr-secret-operator -w
+```
+
+### 4. Run through the manual test steps above (Create a test CR onwards)
+
+### 5. Tear down
+
+```bash
+operator-sdk cleanup ecr-secret-operator --namespace ecr-secret-operator
+oc delete project test-ecr-secret-operator ecr-secret-operator
+```
+
+---
+
+## Releasing to OperatorHub
+
+OperatorHub publishing is **fully automated** via the [`publish-operatorhub`](.github/workflows/publish-operatorhub.yaml) GitHub Actions workflow. Publishing to both the OpenShift OperatorHub and the public OperatorHub is triggered by creating a GitHub Release — no manual bundle copying or PR opening is required.
+
+### Pre-release checklist
+
+Before creating the GitHub Release, complete the following steps locally:
+
+#### 1. Update the version and changelog
+
+Edit `Makefile` and bump:
+
+```makefile
+VERSION ?= <NEW_VERSION>
+```
+
+Update `config/manifests/bases/ecr-secret-operator.clusterserviceversion.yaml`:
+
+- Set `containerImage: quay.io/rh-mobb/ecr-secret-operator:v<NEW_VERSION>`
+- Set `createdAt` to today's date
+
+Add a new entry to `CHANGELOG.md` for the new version.
+
+#### 2. Run the test suite
+
+```bash
+make test
+```
+
+#### 3. Regenerate and validate the bundle locally
+
+```bash
+make bundle IMG=quay.io/rh-mobb/ecr-secret-operator:v<NEW_VERSION>
+```
+
+> **Important:** `make bundle` regenerates `bundle/metadata/annotations.yaml` but does not preserve custom annotations. Verify that the file still contains:
+>
+> ```yaml
+> com.redhat.openshift.versions: "v4.16"
+> ```
+>
+> If it was removed, add it back before proceeding.
+
+```bash
+operator-sdk bundle validate ./bundle --select-optional suite=operatorframework
+operator-sdk bundle validate ./bundle --select-optional name=operatorhub
+operator-sdk bundle validate ./bundle --select-optional name=good-practices
+```
+
+#### 4. Run the full OLM smoke test on OpenShift
+
+Follow the steps in [Testing via OLM](#testing-via-olm) to confirm the operator installs and reconciles correctly via OLM before publishing.
+
+#### 5. Commit and push to main
+
+```bash
+git add -A
+git commit -s -m "Release v<NEW_VERSION>"
+git push origin main
+```
+
+### Creating the GitHub Release (triggers automation)
+
+Once the pre-release checklist is complete, create the GitHub Release:
+
+```bash
+gh release create v<NEW_VERSION> \
+  --title "v<NEW_VERSION>" \
+  --notes-file CHANGELOG.md
+```
+
+This triggers the `publish-operatorhub` workflow automatically. The workflow:
+
+1. Builds and pushes the multi-arch operator image to `quay.io/rh-mobb/ecr-secret-operator:v<NEW_VERSION>`
+2. Regenerates and validates the OLM bundle
+3. Builds and pushes the bundle image to `quay.io/rh-mobb/ecr-secret-operator-bundle:v<NEW_VERSION>`
+4. Opens a PR to [`redhat-openshift-ecosystem/community-operators-prod`](https://github.com/redhat-openshift-ecosystem/community-operators-prod) (OpenShift OperatorHub — FBC format)
+5. Opens a PR to [`k8s-operatorhub/community-operators`](https://github.com/k8s-operatorhub/community-operators) (Public OperatorHub — semver format)
+
+Monitor the workflow run:
+
+```bash
+gh run list --workflow=publish-operatorhub.yaml --limit 5
+gh run watch  # follow the active run
+```
+
+### After the workflow completes
+
+Two PRs will be opened automatically — one to each community repo. Both will run their own CI pipelines. Once the CI checks pass, the PRs require human review and approval by the repo maintainers before merging.
+
+Monitor the PR checks:
+
+```bash
+gh pr checks --repo redhat-openshift-ecosystem/community-operators-prod
+gh pr checks --repo k8s-operatorhub/community-operators
+```
+
+Once both PRs are merged, the new version will appear in OperatorHub within a few hours.
+
+---
+
+## GitHub Actions Workflows
+
+Two workflows live in `.github/workflows/`:
+
+### `ci.yaml` — Continuous Integration
+
+Triggers on every push to `main` and every pull request targeting `main`.
+
+| Step | What it does |
+|---|---|
+| Checkout | Checks out the repository |
+| Set up Go | Installs Go using the version in `go.mod` |
+| Install build tools | Runs `make controller-gen kustomize envtest` |
+| Run tests | Runs `make test` (includes `manifests`, `generate`, `fmt`, `vet`) |
+| Upload coverage | Saves `cover.out` as a workflow artifact |
+
+### `publish-operatorhub.yaml` — Release and Publish
+
+Triggers when a GitHub Release is published.
+
+| Job | Runs on | What it does |
+|---|---|---|
+| `build-and-push` | `ubuntu-latest` | Builds multi-arch operator image, generates and validates OLM bundle, builds and pushes bundle image, uploads bundle as artifact |
+| `publish-openshift-operatorhub` | `ubuntu-latest` | Copies bundle into the FBC-based `community-operators-prod` fork, updates `catalog-templates/basic.yaml` and `release-config.yaml` with the new version's upgrade graph, opens PR |
+| `publish-public-operatorhub` | `ubuntu-latest` | Copies bundle into the semver-based `community-operators` fork, opens PR |
+
+### Required repository secrets
+
+Configure these under **Settings → Secrets and variables → Actions**:
+
+| Secret | Description |
+|---|---|
+| `QUAY_USERNAME` | Quay.io robot account username (e.g. `rh-mobb+robot`) |
+| `QUAY_PASSWORD` | Quay.io robot account token |
+| `OPERATORHUB_PR_TOKEN` | GitHub Personal Access Token (classic) with `public_repo` scope, belonging to an account that has forked both community repos under the `rh-mobb` org |
+
+### Required forks
+
+The `publish-operatorhub` workflow pushes to forks before opening upstream PRs. Ensure these forks exist under the `rh-mobb` org:
+
+```bash
+gh repo fork redhat-openshift-ecosystem/community-operators-prod \
+  --org rh-mobb --clone=false
+
+gh repo fork k8s-operatorhub/community-operators \
+  --org rh-mobb --clone=false
+```
+
+---
+
+## Commit and PR Guidelines
+
+- All commits must be signed off with `-s` (`git commit -s`) to satisfy the DCO requirement used by the upstream OperatorHub repos.
+- Each PR to the community operator repos must contain exactly **one** commit. Use `git rebase -i origin/main` to squash before pushing.
+- Branch naming: `bug/<issue-number>` for bug fixes, `feat/<description>` for features, `release/v<version>` for releases.
+- Run `make test` before opening any PR against this repository.


### PR DESCRIPTION
## Summary

This PR adds GitHub Actions release automation, CI pipeline improvements, and contributor documentation on top of the v0.5.0 release.

### GitHub Actions Automation

- **`ci.yaml`** — runs on every PR and push to `main`; three parallel jobs: unit tests, multi-arch operator image build, and OLM bundle generation and validation; PR builds are pushed to `quay.io/rh-mobb/ecr-secret-operator:pr-<number>` and `quay.io/rh-mobb/ecr-secret-operator-bundle:pr-<number>` for manual OLM testing before merge
- **`publish-operatorhub.yaml`** — triggered by GitHub Release publication; builds and pushes the production operator and bundle images, then opens PRs to both `redhat-openshift-ecosystem/community-operators-prod` (FBC format) and `k8s-operatorhub/community-operators` (semver format)
- **`sync-forks.yaml`** — reusable workflow called by `publish-operatorhub.yaml` before any PR is opened; can also be triggered manually to reset fork `main` branches to upstream
- **`add-openshift-version.yaml`** — runs daily; detects new OpenShift minor version catalog directories in `community-operators-prod` and automatically opens a PR to add them to the operator's FBC `catalog_mapping`

### Documentation

- Added `CONTRIBUTING.md` covering prerequisites, repository layout, development setup, testing (unit, manual deploy, OLM via PR build and release build), the full release process, all four GitHub Actions workflows, bot account and secrets setup, and commit/PR guidelines
- Added `CHANGELOG.md` with entries for all versions from `v0.1.1` through `v0.5.0`

## Test Plan

- [x] CI jobs pass on this PR (`test`, `build-image`, `build-bundle`)
- [x] `sync-forks.yaml` triggered manually and completes successfully
- [x] `add-openshift-version.yaml` triggered manually and completes successfully