### PR TITLE
Add e2e test pipeline with ROSA HCP, ECR, and GitHub Actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -122,7 +122,7 @@ jobs:
 
       - name: Generate OLM bundle
         run: |
-          make bundle IMG=${{ env.IMAGE_TAG_BASE }}:ci-${{ github.sha }}
+          make bundle IMG=${{ env.IMAGE_TAG_BASE }}:pr-${{ github.event.pull_request.number || github.sha }}
 
       - name: Restore com.redhat.openshift.versions annotation
         # make bundle regenerates annotations.yaml and drops custom annotations
@@ -163,14 +163,11 @@ jobs:
         run: |
           podman build \
             -f bundle.Dockerfile \
-            -t ${{ env.IMAGE_TAG_BASE }}-bundle:ci-${{ github.sha }} \
+            -t ${{ env.IMAGE_TAG_BASE }}-bundle:pr-${{ github.event.pull_request.number || github.sha }} \
             .
 
       - name: Push PR bundle image
-        # Push a pr-<number> tag so it can be pulled for manual OLM testing.
-        # Skipped on forks where QUAY_USERNAME is not available.
         if: ${{ github.event_name == 'pull_request' && env.HAS_QUAY_CREDENTIALS == 'true' }}
         run: |
           podman push \
-            ${{ env.IMAGE_TAG_BASE }}-bundle:ci-${{ github.sha }} \
             ${{ env.IMAGE_TAG_BASE }}-bundle:pr-${{ github.event.pull_request.number }}

--- a/.github/workflows/e2e-cleanup.yaml
+++ b/.github/workflows/e2e-cleanup.yaml
@@ -1,0 +1,106 @@
+name: E2E Cleanup
+
+on:
+  issue_comment:
+    types: [created]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "PR number whose infrastructure to destroy"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  pull-requests: read
+  issues: write
+  id-token: write
+
+env:
+  AWS_REGION: us-east-2
+  CLUSTER_NAME_PREFIX: ecr-e2e
+
+jobs:
+  check-permission:
+    name: Verify authorization
+    runs-on: ubuntu-latest
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.issue.pull_request &&
+       contains(github.event.comment.body, '/destroy-e2e'))
+    outputs:
+      authorized: ${{ steps.check.outputs.authorized }}
+      pr_number: ${{ steps.pr.outputs.number }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Determine PR number
+        id: pr
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "number=${{ inputs.pr_number }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "number=${{ github.event.issue.number }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Check if commenter is authorized
+        id: check
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "authorized=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          COMMENTER="${{ github.event.comment.user.login }}"
+          if grep -q "@${COMMENTER}" CODEOWNERS 2>/dev/null; then
+            echo "authorized=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "authorized=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::User ${COMMENTER} is not in CODEOWNERS"
+          fi
+
+  destroy:
+    name: Destroy e2e infrastructure
+    runs-on: ubuntu-latest
+    needs: [check-permission]
+    if: needs.check-permission.outputs.authorized == 'true'
+    environment: e2e-test
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::660250927410:role/ecr-secret-operator-e2e
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Set up Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "1.9"
+          terraform_wrapper: false
+
+      - name: Terraform Init
+        working-directory: test/e2e/terraform
+        run: terraform init -backend-config="key=pr-${{ needs.check-permission.outputs.pr_number }}/terraform.tfstate"
+
+      - name: Terraform Destroy
+        working-directory: test/e2e/terraform
+        env:
+          RHCS_CLIENT_ID: ${{ secrets.RHCS_CLIENT_ID }}
+          RHCS_CLIENT_SECRET: ${{ secrets.RHCS_CLIENT_SECRET }}
+        run: |
+          terraform destroy -auto-approve \
+            -var="cluster_name=${{ env.CLUSTER_NAME_PREFIX }}-${{ needs.check-permission.outputs.pr_number }}" \
+            -var="aws_region=${{ env.AWS_REGION }}" \
+            -var="pr_number=${{ needs.check-permission.outputs.pr_number }}"
+
+      - name: React to comment
+        if: github.event_name == 'issue_comment'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh api repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions \
+            -f content='+1'

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1,0 +1,194 @@
+name: E2E Tests
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+  id-token: write
+
+env:
+  IMAGE_TAG_BASE: quay.io/rh-mobb/ecr-secret-operator
+  AWS_REGION: us-east-2
+  CLUSTER_NAME_PREFIX: ecr-e2e
+
+jobs:
+  provision:
+    name: Provision ROSA HCP cluster and ECR
+    runs-on: ubuntu-latest
+    environment: e2e-test
+    timeout-minutes: 60
+    outputs:
+      cluster_name: ${{ steps.tf-output.outputs.cluster_name }}
+      cluster_api_url: ${{ steps.tf-output.outputs.cluster_api_url }}
+      cluster_admin_password: ${{ steps.tf-output.outputs.cluster_admin_password }}
+      ecr_registry: ${{ steps.tf-output.outputs.ecr_registry }}
+      operator_ecr_role_arn: ${{ steps.tf-output.outputs.operator_ecr_role_arn }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::660250927410:role/ecr-secret-operator-e2e
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Set up Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "1.9"
+          terraform_wrapper: false
+
+      - name: Terraform Init
+        working-directory: test/e2e/terraform
+        run: terraform init -backend-config="key=pr-${{ github.event.pull_request.number }}/terraform.tfstate"
+
+      - name: Terraform Apply
+        working-directory: test/e2e/terraform
+        env:
+          RHCS_CLIENT_ID: ${{ secrets.RHCS_CLIENT_ID }}
+          RHCS_CLIENT_SECRET: ${{ secrets.RHCS_CLIENT_SECRET }}
+        run: |
+          terraform apply -auto-approve \
+            -var="cluster_name=${{ env.CLUSTER_NAME_PREFIX }}-${{ github.event.pull_request.number }}" \
+            -var="aws_region=${{ env.AWS_REGION }}" \
+            -var="pr_number=${{ github.event.pull_request.number }}"
+
+      - name: Extract Terraform outputs
+        id: tf-output
+        working-directory: test/e2e/terraform
+        run: |
+          echo "cluster_name=$(terraform output -raw cluster_name)" >> "$GITHUB_OUTPUT"
+          echo "cluster_api_url=$(terraform output -raw cluster_api_url)" >> "$GITHUB_OUTPUT"
+          echo "cluster_admin_password=$(terraform output -raw cluster_admin_password)" >> "$GITHUB_OUTPUT"
+          echo "ecr_registry=$(terraform output -raw ecr_registry_url)" >> "$GITHUB_OUTPUT"
+          echo "operator_ecr_role_arn=$(terraform output -raw operator_ecr_role_arn)" >> "$GITHUB_OUTPUT"
+
+  test:
+    name: Run e2e tests
+    runs-on: ubuntu-latest
+    needs: [provision]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::660250927410:role/ecr-secret-operator-e2e
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Install CLI tools
+        run: |
+          curl -sSL https://mirror.openshift.com/pub/openshift-v4/clients/ocp/stable/openshift-client-linux.tar.gz \
+            | sudo tar xzf - -C /usr/local/bin oc kubectl
+
+          OPERATOR_SDK_VERSION=v1.42.0
+          curl -sSLo /usr/local/bin/operator-sdk \
+            "https://github.com/operator-framework/operator-sdk/releases/download/${OPERATOR_SDK_VERSION}/operator-sdk_linux_amd64"
+          chmod +x /usr/local/bin/operator-sdk
+
+      - name: Log in to ROSA cluster
+        run: |
+          oc login "${{ needs.provision.outputs.cluster_api_url }}" \
+            --username cluster-admin \
+            --password "${{ needs.provision.outputs.cluster_admin_password }}" \
+            --insecure-skip-tls-verify=true
+
+      - name: Create operator namespace and AWS credentials
+        run: |
+          NAMESPACE="ecr-secret-operator"
+          oc create namespace "${NAMESPACE}" --dry-run=client -o yaml | oc apply -f -
+
+          # Create credentials file for STS role assumption via OIDC
+          cat > /tmp/credentials <<EOF
+          [default]
+          role_arn = ${{ needs.provision.outputs.operator_ecr_role_arn }}
+          web_identity_token_file = /var/run/secrets/openshift/serviceaccount/token
+          EOF
+
+          oc create secret generic aws-ecr-cloud-credentials \
+            --namespace="${NAMESPACE}" \
+            --from-file=credentials=/tmp/credentials \
+            --dry-run=client -o yaml | oc apply -f -
+
+      - name: Install operator via OLM bundle
+        run: |
+          operator-sdk run bundle \
+            "${{ env.IMAGE_TAG_BASE }}-bundle:pr-${{ github.event.pull_request.number }}" \
+            --namespace ecr-secret-operator \
+            --timeout 10m
+
+      - name: Wait for operator readiness
+        run: |
+          oc rollout status deployment/ecr-secret-operator-controller-manager \
+            --namespace ecr-secret-operator \
+            --timeout=300s
+
+      - name: Run e2e test suite
+        env:
+          ECR_REGISTRY: ${{ needs.provision.outputs.ecr_registry }}
+          TEST_NAMESPACE: ecr-secret-operator
+          AWS_REGION: us-east-2
+        run: test/e2e/scripts/run-e2e.sh
+
+      - name: Collect debug logs on failure
+        if: failure()
+        run: |
+          echo "=== Operator logs ==="
+          oc logs deployment/ecr-secret-operator-controller-manager \
+            --namespace ecr-secret-operator \
+            --tail=200 || true
+          echo "=== Events ==="
+          oc get events --namespace ecr-secret-operator --sort-by='.lastTimestamp' || true
+          echo "=== ECR Secret CRs ==="
+          oc get secrets.ecr.mobb.redhat.com --all-namespaces -o yaml || true
+          echo "=== ArgoHelmRepoSecret CRs ==="
+          oc get argohelmreposecrets.ecr.mobb.redhat.com --all-namespaces -o yaml || true
+          echo "=== Core secrets ==="
+          oc get secrets --namespace ecr-secret-operator || true
+
+      - name: Cleanup operator
+        if: always()
+        run: |
+          operator-sdk cleanup ecr-secret-operator --namespace ecr-secret-operator || true
+
+  cleanup:
+    name: Destroy infrastructure
+    runs-on: ubuntu-latest
+    needs: [provision, test]
+    if: always() && !contains(github.event.pull_request.labels.*.name, 'e2e-keep-infra')
+    environment: e2e-test
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::660250927410:role/ecr-secret-operator-e2e
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Set up Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "1.9"
+          terraform_wrapper: false
+
+      - name: Terraform Init
+        working-directory: test/e2e/terraform
+        run: terraform init -backend-config="key=pr-${{ github.event.pull_request.number }}/terraform.tfstate"
+
+      - name: Terraform Destroy
+        working-directory: test/e2e/terraform
+        env:
+          RHCS_CLIENT_ID: ${{ secrets.RHCS_CLIENT_ID }}
+          RHCS_CLIENT_SECRET: ${{ secrets.RHCS_CLIENT_SECRET }}
+        run: |
+          terraform destroy -auto-approve \
+            -var="cluster_name=${{ env.CLUSTER_NAME_PREFIX }}-${{ github.event.pull_request.number }}" \
+            -var="aws_region=${{ env.AWS_REGION }}" \
+            -var="pr_number=${{ github.event.pull_request.number }}"

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @michaelryanmcneill

--- a/test/e2e/manifests/argo-helm-cr.yaml.tpl
+++ b/test/e2e/manifests/argo-helm-cr.yaml.tpl
@@ -1,0 +1,10 @@
+apiVersion: ecr.mobb.redhat.com/v1alpha1
+kind: ArgoHelmRepoSecret
+metadata:
+  name: e2e-argo-helm-secret
+  namespace: ${TEST_NAMESPACE}
+spec:
+  generated_secret_name: "e2e-helm-repo-secret"
+  url: "https://${ECR_REGISTRY}/${ECR_REPO_NAME}"
+  region: "${AWS_REGION}"
+  frequency: "1h"

--- a/test/e2e/manifests/secret-cr-invalid-region.yaml.tpl
+++ b/test/e2e/manifests/secret-cr-invalid-region.yaml.tpl
@@ -1,0 +1,10 @@
+apiVersion: ecr.mobb.redhat.com/v1alpha1
+kind: Secret
+metadata:
+  name: e2e-ecr-secret-bad-region
+  namespace: ${TEST_NAMESPACE}
+spec:
+  generated_secret_name: "e2e-docker-pull-secret-bad"
+  ecr_registry: "${ECR_REGISTRY}"
+  region: "xx-invalid-99"
+  frequency: "1h"

--- a/test/e2e/manifests/secret-cr.yaml.tpl
+++ b/test/e2e/manifests/secret-cr.yaml.tpl
@@ -1,0 +1,10 @@
+apiVersion: ecr.mobb.redhat.com/v1alpha1
+kind: Secret
+metadata:
+  name: e2e-ecr-secret
+  namespace: ${TEST_NAMESPACE}
+spec:
+  generated_secret_name: "e2e-docker-pull-secret"
+  ecr_registry: "${ECR_REGISTRY}"
+  region: "${AWS_REGION}"
+  frequency: "1h"

--- a/test/e2e/scripts/run-e2e.sh
+++ b/test/e2e/scripts/run-e2e.sh
@@ -1,0 +1,320 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${ECR_REGISTRY:?ECR_REGISTRY must be set}"
+: "${TEST_NAMESPACE:?TEST_NAMESPACE must be set}"
+: "${AWS_REGION:=us-east-2}"
+export ECR_REPO_NAME="${ECR_REPO_NAME:-ecr-e2e-test-repo}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MANIFESTS_DIR="${SCRIPT_DIR}/../manifests"
+PASS=0
+FAIL=0
+TESTS_RUN=0
+
+log()  { echo "--- [$(date +%H:%M:%S)] $*"; }
+pass() { log "PASS: $1"; PASS=$((PASS + 1)); }
+fail() { log "FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+render_template() {
+  envsubst < "$1"
+}
+
+wait_for_secret() {
+  local name="$1" timeout="$2"
+  log "Waiting up to ${timeout}s for secret/${name}..."
+  local end=$((SECONDS + timeout))
+  while [ $SECONDS -lt $end ]; do
+    if oc get secret "$name" -n "$TEST_NAMESPACE" &>/dev/null; then
+      return 0
+    fi
+    sleep 5
+  done
+  return 1
+}
+
+wait_for_cr_phase() {
+  local kind="$1" name="$2" expected="$3" timeout="$4"
+  log "Waiting up to ${timeout}s for ${kind}/${name} phase=${expected}..."
+  local end=$((SECONDS + timeout))
+  while [ $SECONDS -lt $end ]; do
+    local phase
+    phase=$(oc get "$kind" "$name" -n "$TEST_NAMESPACE" \
+              -o jsonpath='{.status.phase}' 2>/dev/null || echo "")
+    if [ "$phase" = "$expected" ]; then
+      return 0
+    fi
+    sleep 5
+  done
+  return 1
+}
+
+cleanup_cr() {
+  oc delete "$1" "$2" -n "$TEST_NAMESPACE" --ignore-not-found=true 2>/dev/null || true
+}
+
+cleanup_secret() {
+  oc delete secret "$1" -n "$TEST_NAMESPACE" --ignore-not-found=true 2>/dev/null || true
+}
+
+operator_is_running() {
+  local ready
+  ready=$(oc get deployment ecr-secret-operator-controller-manager \
+            -n "$TEST_NAMESPACE" \
+            -o jsonpath='{.status.readyReplicas}' 2>/dev/null || echo "0")
+  [ "${ready:-0}" -ge 1 ]
+}
+
+# =========================================================================
+# Test 1: Secret CR creates dockerconfigjson secret
+# =========================================================================
+test_secret_cr_positive() {
+  local test_name="Secret CR creates dockerconfigjson secret"
+  TESTS_RUN=$((TESTS_RUN + 1))
+  log "TEST: ${test_name}"
+
+  cleanup_cr "secrets.ecr.mobb.redhat.com" "e2e-ecr-secret"
+  cleanup_secret "e2e-docker-pull-secret"
+
+  render_template "${MANIFESTS_DIR}/secret-cr.yaml.tpl" | oc apply -f -
+
+  if ! wait_for_secret "e2e-docker-pull-secret" 120; then
+    fail "${test_name} - generated secret not created within timeout"
+    return
+  fi
+
+  local secret_type
+  secret_type=$(oc get secret "e2e-docker-pull-secret" -n "$TEST_NAMESPACE" \
+                  -o jsonpath='{.type}')
+  if [ "$secret_type" != "kubernetes.io/dockerconfigjson" ]; then
+    fail "${test_name} - expected type kubernetes.io/dockerconfigjson, got ${secret_type}"
+    return
+  fi
+
+  local data_len
+  data_len=$(oc get secret "e2e-docker-pull-secret" -n "$TEST_NAMESPACE" \
+               -o jsonpath='{.data.\.dockerconfigjson}' | wc -c)
+  if [ "$data_len" -lt 10 ]; then
+    fail "${test_name} - .dockerconfigjson data is empty or too short"
+    return
+  fi
+
+  if ! wait_for_cr_phase "secrets.ecr.mobb.redhat.com" "e2e-ecr-secret" "Updated" 60; then
+    fail "${test_name} - CR status.phase never reached 'Updated'"
+    return
+  fi
+
+  local last_updated
+  last_updated=$(oc get secrets.ecr.mobb.redhat.com "e2e-ecr-secret" -n "$TEST_NAMESPACE" \
+                   -o jsonpath='{.status.lastUpdatedTime}')
+  if [ -z "$last_updated" ]; then
+    fail "${test_name} - status.lastUpdatedTime is empty"
+    return
+  fi
+
+  pass "${test_name}"
+}
+
+# =========================================================================
+# Test 2: ArgoHelmRepoSecret CR creates repo secret
+# =========================================================================
+test_argo_helm_cr_positive() {
+  local test_name="ArgoHelmRepoSecret CR creates repo secret"
+  TESTS_RUN=$((TESTS_RUN + 1))
+  log "TEST: ${test_name}"
+
+  cleanup_cr "argohelmreposecrets.ecr.mobb.redhat.com" "e2e-argo-helm-secret"
+  cleanup_secret "e2e-helm-repo-secret"
+
+  render_template "${MANIFESTS_DIR}/argo-helm-cr.yaml.tpl" | oc apply -f -
+
+  if ! wait_for_secret "e2e-helm-repo-secret" 120; then
+    fail "${test_name} - generated secret not created within timeout"
+    return
+  fi
+
+  for key in username password url type enableOCI name; do
+    local val
+    val=$(oc get secret "e2e-helm-repo-secret" -n "$TEST_NAMESPACE" \
+            -o jsonpath="{.data.${key}}" 2>/dev/null || echo "")
+    if [ -z "$val" ]; then
+      fail "${test_name} - missing data key '${key}'"
+      return
+    fi
+  done
+
+  local label
+  label=$(oc get secret "e2e-helm-repo-secret" -n "$TEST_NAMESPACE" \
+            -o jsonpath='{.metadata.labels.argocd\.argoproj\.io/secret-type}')
+  if [ "$label" != "repository" ]; then
+    fail "${test_name} - expected argocd label 'repository', got '${label}'"
+    return
+  fi
+
+  if ! wait_for_cr_phase "argohelmreposecrets.ecr.mobb.redhat.com" \
+         "e2e-argo-helm-secret" "Updated" 60; then
+    fail "${test_name} - CR status.phase never reached 'Updated'"
+    return
+  fi
+
+  pass "${test_name}"
+}
+
+# =========================================================================
+# Test 3: Delete and recreate CR produces new secret
+# =========================================================================
+test_delete_recreate_cr() {
+  local test_name="Delete and recreate Secret CR produces new secret"
+  TESTS_RUN=$((TESTS_RUN + 1))
+  log "TEST: ${test_name}"
+
+  cleanup_cr "secrets.ecr.mobb.redhat.com" "e2e-ecr-secret"
+  cleanup_secret "e2e-docker-pull-secret"
+  sleep 5
+
+  render_template "${MANIFESTS_DIR}/secret-cr.yaml.tpl" | oc apply -f -
+
+  if ! wait_for_secret "e2e-docker-pull-secret" 120; then
+    fail "${test_name} - secret not created after CR recreation"
+    return
+  fi
+
+  if ! wait_for_cr_phase "secrets.ecr.mobb.redhat.com" "e2e-ecr-secret" "Updated" 60; then
+    fail "${test_name} - CR phase not 'Updated' after recreation"
+    return
+  fi
+
+  pass "${test_name}"
+}
+
+# =========================================================================
+# Test 4: Reconciliation recreates deleted secret
+# =========================================================================
+test_secret_reconciliation() {
+  local test_name="Operator recreates deleted secret (reconciliation)"
+  TESTS_RUN=$((TESTS_RUN + 1))
+  log "TEST: ${test_name}"
+
+  if ! oc get secrets.ecr.mobb.redhat.com "e2e-ecr-secret" -n "$TEST_NAMESPACE" &>/dev/null; then
+    render_template "${MANIFESTS_DIR}/secret-cr.yaml.tpl" | oc apply -f -
+    wait_for_secret "e2e-docker-pull-secret" 120
+  fi
+
+  log "Deleting generated secret to test reconciliation..."
+  oc delete secret "e2e-docker-pull-secret" -n "$TEST_NAMESPACE"
+
+  # The controller uses GenerationChangedPredicate, so deleting the generated
+  # secret alone won't trigger reconcile. Patch a spec field to bump the
+  # CR's generation and force a reconcile cycle.
+  log "Patching CR frequency to trigger reconciliation..."
+  oc patch secrets.ecr.mobb.redhat.com "e2e-ecr-secret" \
+    -n "$TEST_NAMESPACE" \
+    --type merge -p '{"spec":{"frequency":"2h"}}'
+
+  if ! wait_for_secret "e2e-docker-pull-secret" 120; then
+    fail "${test_name} - secret was not recreated after deletion + reconcile trigger"
+    return
+  fi
+
+  # Restore original frequency
+  oc patch secrets.ecr.mobb.redhat.com "e2e-ecr-secret" \
+    -n "$TEST_NAMESPACE" \
+    --type merge -p '{"spec":{"frequency":"1h"}}' || true
+
+  pass "${test_name}"
+}
+
+# =========================================================================
+# Test 5: Invalid region doesn't crash operator
+# =========================================================================
+test_invalid_region() {
+  local test_name="Secret CR with invalid region does not crash operator"
+  TESTS_RUN=$((TESTS_RUN + 1))
+  log "TEST: ${test_name}"
+
+  cleanup_cr "secrets.ecr.mobb.redhat.com" "e2e-ecr-secret-bad-region"
+  cleanup_secret "e2e-docker-pull-secret-bad"
+
+  render_template "${MANIFESTS_DIR}/secret-cr-invalid-region.yaml.tpl" | oc apply -f -
+
+  sleep 30
+
+  if oc get secret "e2e-docker-pull-secret-bad" -n "$TEST_NAMESPACE" &>/dev/null; then
+    fail "${test_name} - secret was created despite invalid region"
+    cleanup_cr "secrets.ecr.mobb.redhat.com" "e2e-ecr-secret-bad-region"
+    cleanup_secret "e2e-docker-pull-secret-bad"
+    return
+  fi
+
+  if ! operator_is_running; then
+    fail "${test_name} - operator crashed after invalid region CR"
+    cleanup_cr "secrets.ecr.mobb.redhat.com" "e2e-ecr-secret-bad-region"
+    return
+  fi
+
+  pass "${test_name}"
+  cleanup_cr "secrets.ecr.mobb.redhat.com" "e2e-ecr-secret-bad-region"
+}
+
+# =========================================================================
+# Test 6: Non-existent registry fails gracefully
+# =========================================================================
+test_nonexistent_registry() {
+  local test_name="Secret CR with non-existent registry fails gracefully"
+  TESTS_RUN=$((TESTS_RUN + 1))
+  log "TEST: ${test_name}"
+
+  local cr_name="e2e-ecr-secret-bad-registry"
+  local secret_name="e2e-docker-pull-secret-bad-reg"
+  cleanup_cr "secrets.ecr.mobb.redhat.com" "$cr_name"
+  cleanup_secret "$secret_name"
+
+  cat <<EOF | oc apply -f -
+apiVersion: ecr.mobb.redhat.com/v1alpha1
+kind: Secret
+metadata:
+  name: ${cr_name}
+  namespace: ${TEST_NAMESPACE}
+spec:
+  generated_secret_name: "${secret_name}"
+  ecr_registry: "000000000000.dkr.ecr.${AWS_REGION}.amazonaws.com"
+  region: "${AWS_REGION}"
+  frequency: "1h"
+EOF
+
+  sleep 30
+
+  if ! operator_is_running; then
+    fail "${test_name} - operator crashed"
+  else
+    pass "${test_name}"
+  fi
+
+  cleanup_cr "secrets.ecr.mobb.redhat.com" "$cr_name"
+  cleanup_secret "$secret_name"
+}
+
+# =========================================================================
+# Main
+# =========================================================================
+log "Starting e2e test suite"
+log "ECR_REGISTRY=${ECR_REGISTRY}"
+log "TEST_NAMESPACE=${TEST_NAMESPACE}"
+log "AWS_REGION=${AWS_REGION}"
+echo ""
+
+test_secret_cr_positive
+test_argo_helm_cr_positive
+test_delete_recreate_cr
+test_secret_reconciliation
+test_invalid_region
+test_nonexistent_registry
+
+echo ""
+log "=========================================="
+log "E2E Test Results: ${TESTS_RUN} run, ${PASS} passed, ${FAIL} failed"
+log "=========================================="
+
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi

--- a/test/e2e/terraform/main.tf
+++ b/test/e2e/terraform/main.tf
@@ -1,0 +1,129 @@
+data "aws_caller_identity" "current" {}
+
+data "rhcs_versions" "latest" {
+  search = "enabled='t' and rosa_enabled='t' and channel_group='stable' and hosted_control_plane_enabled='t'"
+  order  = "id desc"
+}
+
+locals {
+  openshift_version = data.rhcs_versions.latest.items[0].name
+}
+
+locals {
+  common_tags = {
+    "app-code"      = "MOBB-001"
+    "service-phase" = "lab"
+    "owner"         = "github-actions"
+    "repo"          = "ecr-secret-operator"
+    "pr"            = var.pr_number
+  }
+}
+
+# --- VPC (single AZ to minimise cost) ---
+
+module "vpc" {
+  source  = "terraform-redhat/rosa-hcp/rhcs//modules/vpc"
+  version = "1.7.4"
+
+  name_prefix              = var.cluster_name
+  availability_zones_count = 1
+  vpc_cidr                 = "10.0.0.0/16"
+
+  tags = merge(local.common_tags, {
+    "e2e-test" = "true"
+    "cluster"  = var.cluster_name
+  })
+}
+
+# --- Cluster admin password ---
+
+resource "random_password" "cluster_admin" {
+  length           = 24
+  special          = true
+  override_special = "!#%&*()-_=+[]{}:?"
+}
+
+# --- ROSA HCP cluster ---
+
+module "rosa_hcp" {
+  source  = "terraform-redhat/rosa-hcp/rhcs"
+  version = "1.7.4"
+
+  cluster_name           = var.cluster_name
+  openshift_version      = local.openshift_version
+  machine_cidr           = module.vpc.cidr_block
+  aws_subnet_ids         = concat(module.vpc.private_subnets, module.vpc.public_subnets)
+  aws_availability_zones = module.vpc.availability_zones
+  replicas               = var.replicas
+  compute_machine_type   = var.compute_machine_type
+
+  create_account_roles  = true
+  account_role_prefix   = "${var.cluster_name}-acct"
+  create_oidc           = true
+  create_operator_roles = true
+  operator_role_prefix  = "${var.cluster_name}-op"
+
+  admin_credentials_username = "cluster-admin"
+  admin_credentials_password = random_password.cluster_admin.result
+
+  wait_for_create_complete = true
+
+  tags = merge(local.common_tags, {
+    "e2e-test" = "true"
+  })
+}
+
+# --- IAM role for operator ECR access (OIDC federation) ---
+
+data "aws_iam_openid_connect_provider" "rosa" {
+  url = "https://${module.rosa_hcp.oidc_endpoint_url}"
+}
+
+resource "aws_iam_role" "operator_ecr" {
+  name = "${var.cluster_name}-ecr-operator"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Principal = {
+        Federated = data.aws_iam_openid_connect_provider.rosa.arn
+      }
+      Action = "sts:AssumeRoleWithWebIdentity"
+      Condition = {
+        StringEquals = {
+          "${module.rosa_hcp.oidc_endpoint_url}:sub" = "system:serviceaccount:ecr-secret-operator:ecr-secret-operator-controller-manager"
+        }
+      }
+    }]
+  })
+
+  tags = merge(local.common_tags, { "e2e-test" = "true" })
+}
+
+resource "aws_iam_role_policy" "operator_ecr" {
+  name = "ecr-get-token"
+  role = aws_iam_role.operator_ecr.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect   = "Allow"
+      Action   = "ecr:GetAuthorizationToken"
+      Resource = "*"
+    }]
+  })
+}
+
+# --- ECR repository ---
+
+resource "aws_ecr_repository" "test" {
+  name                 = var.ecr_repository_name
+  image_tag_mutability = "MUTABLE"
+  force_delete         = true
+
+  tags = merge(local.common_tags, {
+    "e2e-test" = "true"
+    "cluster"  = var.cluster_name
+  })
+}

--- a/test/e2e/terraform/outputs.tf
+++ b/test/e2e/terraform/outputs.tf
@@ -1,0 +1,40 @@
+output "cluster_name" {
+  description = "ROSA HCP cluster name"
+  value       = var.cluster_name
+}
+
+output "cluster_api_url" {
+  description = "Cluster API server URL"
+  value       = module.rosa_hcp.cluster_api_url
+}
+
+output "cluster_console_url" {
+  description = "Cluster web console URL"
+  value       = module.rosa_hcp.cluster_console_url
+}
+
+output "cluster_admin_password" {
+  description = "Cluster admin password"
+  value       = random_password.cluster_admin.result
+  sensitive   = true
+}
+
+output "ecr_registry_url" {
+  description = "ECR registry URL (account-level, without repo name)"
+  value       = "${data.aws_caller_identity.current.account_id}.dkr.ecr.${var.aws_region}.amazonaws.com"
+}
+
+output "ecr_repository_url" {
+  description = "Full ECR repository URL"
+  value       = aws_ecr_repository.test.repository_url
+}
+
+output "aws_account_id" {
+  description = "AWS account ID"
+  value       = data.aws_caller_identity.current.account_id
+}
+
+output "operator_ecr_role_arn" {
+  description = "IAM role ARN for the operator to assume via OIDC for ECR access"
+  value       = aws_iam_role.operator_ecr.arn
+}

--- a/test/e2e/terraform/variables.tf
+++ b/test/e2e/terraform/variables.tf
@@ -1,0 +1,33 @@
+variable "cluster_name" {
+  description = "Name of the ROSA HCP cluster"
+  type        = string
+}
+
+variable "aws_region" {
+  description = "AWS region for all resources"
+  type        = string
+  default     = "us-east-2"
+}
+
+variable "compute_machine_type" {
+  description = "EC2 instance type for worker nodes"
+  type        = string
+  default     = "m7i.xlarge"
+}
+
+variable "replicas" {
+  description = "Number of worker nodes"
+  type        = number
+  default     = 2
+}
+
+variable "ecr_repository_name" {
+  description = "Name of the ECR repository for testing"
+  type        = string
+  default     = "ecr-e2e-test-repo"
+}
+
+variable "pr_number" {
+  description = "Pull request number (used for resource tagging)"
+  type        = string
+}

--- a/test/e2e/terraform/versions.tf
+++ b/test/e2e/terraform/versions.tf
@@ -1,0 +1,39 @@
+terraform {
+  required_version = ">= 1.5.7"
+
+  backend "s3" {
+    bucket = "ecr-secret-operator-e2e-tfstate"
+    region = "us-east-2"
+  }
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
+    }
+    rhcs = {
+      source  = "terraform-redhat/rhcs"
+      version = ">= 1.7.7"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.5"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+
+  default_tags {
+    tags = {
+      "app-code"      = "MOBB-001"
+      "service-phase" = "lab"
+      "owner"         = "github-actions"
+      "repo"          = "ecr-secret-operator"
+      "pr"            = var.pr_number
+    }
+  }
+}
+
+provider "rhcs" {}


### PR DESCRIPTION
Provision a ROSA HCP cluster and ECR repository via Terraform, install the operator through OLM, and run positive/negative tests against real AWS infrastructure. The pipeline is gated by a GitHub environment protection rule requiring CODEOWNER approval before provisioning.

- Terraform configs for VPC, ROSA HCP cluster, and ECR repository
- GitHub Actions workflows for e2e lifecycle and manual cleanup
- Shell-based test suite covering Secret and ArgoHelmRepoSecret CRs
- AWS auth via GitHub OIDC role assumption (no static credentials)
- RHCS auth via OCM service account (RHCS_CLIENT_ID/SECRET)
- Mandatory AWS resource tags (app-code, service-phase, owner, repo, pr)
- CODEOWNERS file for approval gate enforcement