### PR TITLE
Update GitHub Actions to latest major versions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,10 +19,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: "1.26"
           cache: true
@@ -34,7 +34,7 @@ jobs:
         run: make test
 
       - name: Upload coverage
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: coverage
           path: cover.out
@@ -49,16 +49,16 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: "1.26"
           cache: true
 
       - name: Set up QEMU (for multi-arch builds)
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
         with:
           platforms: linux/amd64,linux/arm64
 
@@ -102,10 +102,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: "1.26"
           cache: true

--- a/.github/workflows/e2e-cleanup.yaml
+++ b/.github/workflows/e2e-cleanup.yaml
@@ -33,7 +33,7 @@ jobs:
       pr_number: ${{ steps.pr.outputs.number }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Determine PR number
         id: pr
@@ -68,16 +68,16 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: arn:aws:iam::660250927410:role/ecr-secret-operator-e2e
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Set up Terraform
-        uses: hashicorp/setup-terraform@v3
+        uses: hashicorp/setup-terraform@v4
         with:
           terraform_version: "1.9"
           terraform_wrapper: false

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -27,16 +27,16 @@ jobs:
       operator_ecr_role_arn: ${{ steps.tf-output.outputs.operator_ecr_role_arn }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: arn:aws:iam::660250927410:role/ecr-secret-operator-e2e
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Set up Terraform
-        uses: hashicorp/setup-terraform@v3
+        uses: hashicorp/setup-terraform@v4
         with:
           terraform_version: "1.9"
           terraform_wrapper: false
@@ -72,10 +72,10 @@ jobs:
     needs: [provision]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: arn:aws:iam::660250927410:role/ecr-secret-operator-e2e
           aws-region: ${{ env.AWS_REGION }}
@@ -164,16 +164,16 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: arn:aws:iam::660250927410:role/ecr-secret-operator-e2e
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Set up Terraform
-        uses: hashicorp/setup-terraform@v3
+        uses: hashicorp/setup-terraform@v4
         with:
           terraform_version: "1.9"
           terraform_wrapper: false

--- a/.github/workflows/publish-operatorhub.yaml
+++ b/.github/workflows/publish-operatorhub.yaml
@@ -46,7 +46,7 @@ jobs:
 
     steps:
       - name: Checkout operator repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Parse version from release tag
         id: version
@@ -54,7 +54,7 @@ jobs:
         run: echo "VERSION=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: "1.26"
           cache: true
@@ -121,7 +121,7 @@ jobs:
             BUNDLE_IMG=${{ env.IMAGE_TAG_BASE }}-bundle:${{ github.ref_name }}
 
       - name: Upload bundle as artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: bundle
           path: bundle/
@@ -143,13 +143,13 @@ jobs:
 
     steps:
       - name: Download bundle artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: bundle
           path: bundle/
 
       - name: Checkout community-operators-prod upstream
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           repository: redhat-openshift-ecosystem/community-operators-prod
           path: community-operators-prod
@@ -334,13 +334,13 @@ jobs:
 
     steps:
       - name: Download bundle artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: bundle
           path: bundle/
 
       - name: Checkout community-operators upstream
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           repository: k8s-operatorhub/community-operators
           path: community-operators


### PR DESCRIPTION
- actions/checkout v4 → v7
- actions/setup-go v5 → v6
- actions/upload-artifact v4 → v7
- actions/download-artifact v4 → v7
- aws-actions/configure-aws-credentials v4 → v6
- docker/setup-qemu-action v3 → v4
- hashicorp/setup-terraform v3 → v4

Resolves Node.js 20 deprecation warnings.