### PR TITLE
Release 0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.0] — 2026-07-08
+
+### Features
+
+- **Added end-to-end test pipeline with ROSA HCP, ECR, and GitHub Actions.** Provisions a ROSA HCP cluster and ECR repository via Terraform, installs the operator through OLM, and runs positive/negative tests against real AWS infrastructure. The pipeline is gated by a GitHub environment protection rule requiring CODEOWNER approval before provisioning. ([#36](https://github.com/rh-mobb/ecr-secret-operator/pull/36))
+
+### Changes
+
+- **Upgraded Go to 1.26 and modernized all dependencies.** Major dependency upgrades: controller-runtime `v0.14.1` → `v0.24.1`, `k8s.io/*` `v0.26.2` → `v0.36.2`. Migrated from AWS SDK v1 (end-of-support) to `aws-sdk-go-v2`. Unified test framework from mixed Ginkgo v1/v2 to Ginkgo v2 only. Updated Makefile tooling: `controller-gen` `v0.21.0`, `kustomize` `v5.8.1`, `setup-envtest` `release-0.24`, `ENVTEST_K8S_VERSION` `1.31`, `opm` `v1.49.0`. ([#35](https://github.com/rh-mobb/ecr-secret-operator/pull/35))
+- **Updated GitHub Actions to latest major versions.** `actions/checkout` v4 → v7, `actions/setup-go` v5 → v6, `actions/upload-artifact` v4 → v7, `actions/download-artifact` v4 → v7, `aws-actions/configure-aws-credentials` v4 → v6, `docker/setup-qemu-action` v3 → v4, `hashicorp/setup-terraform` v3 → v4. Resolves Node.js 20 deprecation warnings. ([#37](https://github.com/rh-mobb/ecr-secret-operator/pull/37))
+- **Removed OCP auto-promotion workflow and added approval gate to release pipeline.** The `add-openshift-version` workflow has been removed (OpenShift version promotion is now handled by `fbc.version_promotion_strategy: always`). Both `publish-*` jobs now require `operatorhub-publish` environment approval before opening OperatorHub PRs. ([#32](https://github.com/rh-mobb/ecr-secret-operator/pull/32))
+- **Added VPC endpoint cleanup to reduce e2e destroy failures.** Cleans up orphaned VPC endpoints and security groups between cluster and VPC destruction. ([#38](https://github.com/rh-mobb/ecr-secret-operator/pull/38))
+
+### Security
+
+- **Added explicit permissions to all GitHub Actions workflows** to satisfy CodeQL `actions/missing-workflow-permissions` rules. ([#31](https://github.com/rh-mobb/ecr-secret-operator/pull/31))
+- **Added main branch protection restrictions.**
+
+---
+
 ## [0.5.1] — 2026-03-10
 
 ### Security

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 0.5.1
+VERSION ?= 0.6.0
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")

--- a/bundle/manifests/ecr-secret-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ecr-secret-operator.clusterserviceversion.yaml
@@ -37,8 +37,8 @@ metadata:
     capabilities: Basic Install
     categories: Integration & Delivery
     com.redhat.openshift.versions: v4.16
-    containerImage: quay.io/rh-mobb/ecr-secret-operator:v0.5.1
-    createdAt: "2026-03-10T16:20:06Z"
+    containerImage: quay.io/rh-mobb/ecr-secret-operator:v0.6.0
+    createdAt: "2026-07-08T00:00:00Z"
     description: Automatically refreshes AWS ECR authentication tokens as Kubernetes
       image pull secrets before they expire.
     operatorframework.io/suggested-namespace: ecr-secret-operator
@@ -46,7 +46,7 @@ metadata:
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
     repository: https://github.com/rh-mobb/ecr-secret-operator
     support: Community based
-  name: ecr-secret-operator.v0.5.1
+  name: ecr-secret-operator.v0.6.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -213,7 +213,7 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.annotations['olm.targetNamespaces']
-                image: quay.io/rh-mobb/ecr-secret-operator:v0.5.1
+                image: quay.io/rh-mobb/ecr-secret-operator:v0.6.0
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -316,4 +316,4 @@ spec:
   minKubeVersion: 1.29.0
   provider:
     name: Red Hat's Global Cloud Services SSA Team
-  version: 0.5.1
+  version: 0.6.0

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -13,4 +13,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/rh-mobb/ecr-secret-operator
-  newTag: v0.5.1
+  newTag: v0.6.0

--- a/config/manifests/bases/ecr-secret-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/ecr-secret-operator.clusterserviceversion.yaml
@@ -6,7 +6,7 @@ metadata:
     capabilities: Basic Install
     categories: Integration & Delivery
     com.redhat.openshift.versions: v4.16
-    containerImage: quay.io/rh-mobb/ecr-secret-operator:v0.5.1
+    containerImage: quay.io/rh-mobb/ecr-secret-operator:v0.6.0
     createdAt: "2026-03-10T00:00:00Z"
     description: Automatically refreshes AWS ECR authentication tokens as Kubernetes
       image pull secrets before they expire.


### PR DESCRIPTION
## Summary

- Bumps version from 0.5.1 to 0.6.0 across Makefile, OLM bundle CSV, kustomization, and manifests
- Adds CHANGELOG entry for 0.6.0 covering all changes since v0.5.1

## Changes included in 0.6.0

- **e2e test pipeline** with ROSA HCP, ECR, and GitHub Actions (#36)
- **Go 1.26 upgrade** and full dependency modernization including AWS SDK v2 migration (#35)
- **GitHub Actions updated** to latest major versions (#37)
- **Release pipeline approval gate** replacing OCP auto-promotion workflow (#32)
- **VPC endpoint cleanup** for e2e reliability (#38)
- **CodeQL workflow permissions** fix (#31)
- **Main branch protection** restrictions

## Test plan

- [x] e2e pipeline runs successfully against ROSA HCP cluster
- [x] Operator installs via OLM with the new bundle
- [x] Secret and ArgoHelmRepoSecret CRs reconcile correctly